### PR TITLE
Create submodules for cone and add LP utility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,15 @@ os:
 julia:
   - 0.6
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
+before_script:
+  - julia -e 'Pkg.clone("https://github.com/JuliaOpt/MathOptInterface.jl.git")'
+  - julia -e 'Pkg.clone("https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl.git")'
+  - julia -e 'Pkg.clone("https://github.com/JuliaOpt/SemidefiniteOptInterface.jl.git")'
 # uncomment the following lines to override the default test script
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.6
 BinDeps
+MathOptInterface
+SemidefiniteOptInterface

--- a/src/DSDP.jl
+++ b/src/DSDP.jl
@@ -6,6 +6,7 @@ else
     error("DSDP not properly installed. Please run Pkg.build(\"DSDP\")")
 end
 
+const DSDPT = Ptr{Void}
 const SDPCone = Ptr{Void}
 const BCone = Ptr{Void}
 const LPCone = Ptr{Void}

--- a/src/DSDP.jl
+++ b/src/DSDP.jl
@@ -12,7 +12,7 @@ macro dsdp_ccall(f, args...)
         # and leave it as a symbol
         info = ccall(($(QuoteNode(f)), libdsdp), Cint, $(esc.(args)...))
         if !iszero(info)
-            error("DSDP call $f returned nonzero status $info.")
+            error("DSDP call $($(QuoteNode(f))) returned nonzero status $info.")
         end
     end
 end
@@ -51,6 +51,6 @@ end
 #    @dsdp_ccall DSDPPrintSolution (Ptr{FILE}, DSDP, SDPCone.SDPConeT, LPCone.LPConeT) arg1 arg2 arg3 arg4
 #end
 
-#include("DSDPSolverInterface.jl")
+include("DSDPSolverInterface.jl")
 
 end

--- a/src/DSDP.jl
+++ b/src/DSDP.jl
@@ -6,6 +6,18 @@ else
     error("DSDP not properly installed. Please run Pkg.build(\"DSDP\")")
 end
 
+macro dsdp_ccall(f, args...)
+    quote
+        # QuoteNode prevents the interpretion of the symbol
+        # and leave it as a symbol
+        info = ccall(($(QuoteNode(f)), libdsdp), Cint, $(esc.(args)...))
+        if !iszero(info)
+            error("DSDP call $f returned nonzero status $info.")
+        end
+    end
+end
+
+
 const DSDPT = Ptr{Void}
 const SDPCone = Ptr{Void}
 const BCone = Ptr{Void}

--- a/src/DSDP.jl
+++ b/src/DSDP.jl
@@ -17,13 +17,40 @@ macro dsdp_ccall(f, args...)
     end
 end
 
-
 const DSDPT = Ptr{Void}
-const SDPCone = Ptr{Void}
-const BCone = Ptr{Void}
-const LPCone = Ptr{Void}
 
 include("dsdp5_enums.jl")
 include("dsdp5_API.jl")
+
+include("lpcone.jl")
+function CreateLPCone(dsdp::DSDPT)
+    lpcone = Ref{LPCone.LPConeT}()
+    @dsdp_ccall DSDPCreateLPCone (DSDPT, Ref{LPCone.LPConeT}) dsdp lpcone
+    lpcone[]
+end
+
+include("sdpcone.jl")
+function CreateSDPCone(dsdp::DSDPT, n::Integer)
+    sdpcone = Ref{SDPCone.SDPConeT}()
+    @dsdp_ccall DSDPCreateSDPCone (DSDPT, Cint, Ref{SDPCone.SDPConeT}) dsdp n sdpcone
+    sdpcone[]
+end
+
+include("bcone.jl")
+function CreateBCone(dsdp::DSDPT)
+    bcone = Ref{BCone.BConeT}()
+    @dsdp_ccall DSDPCreateBCone (DSDPT, Ref{BCone.BConeT}) dsdp bcone
+    bcone[]
+end
+
+function PrintData(dsdp::DSDPT, arg2::SDPCone.SDPConeT, arg3::LPCone.LPConeT)
+    @dsdp_ccall DSDPPrintData (DSDPT, SDPCone.SDPConeT, LPCone.LPConeT) dsdp arg2 arg3
+end
+
+#function PrintSolution(arg1, arg2::DSDPT, arg3::SDPCone.SDPConeT, arg4::LPCone.LPConeT)
+#    @dsdp_ccall DSDPPrintSolution (Ptr{FILE}, DSDP, SDPCone.SDPConeT, LPCone.LPConeT) arg1 arg2 arg3 arg4
+#end
+
+#include("DSDPSolverInterface.jl")
 
 end

--- a/src/DSDPSolverInterface.jl
+++ b/src/DSDPSolverInterface.jl
@@ -1,0 +1,242 @@
+using SemidefiniteOptInterface
+SOI = SemidefiniteOptInterface
+
+using MathOptInterface
+MOI = MathOptInterface
+
+export DSDPSolver
+
+struct DSDPSolver <: SOI.AbstractSDSolver
+    options::Dict{Symbol,Any}
+end
+DSDPSolver(;kwargs...) = DSDPSolver(Dict{Symbol,Any}(kwargs))
+
+mutable struct DSDPSolverInstance <: SOI.AbstractSDSolverInstance
+    dsdp::DSDPT
+    lpcone::LPCone.LPConeT
+    nconstrs::Int
+    blkdims::Vector{Int}
+    blk::Vector{Int}
+    sdpcone::SDPCone.SDPConeT
+    nlpdrows::Int
+    lpdvars::Vector{Int}
+    lpdrows::Vector{Int}
+    lpcoefs::Vector{Cdouble}
+
+    x_computed::Bool
+    y_valid::Bool
+    y::Vector{Cdouble}
+    z_computed::Bool
+
+    options::Dict{Symbol,Any}
+    function DSDPSolverInstance(; kwargs...)
+        new(C_NULL, C_NULL, 0, Int[], Int[], C_NULL, 0, Int[], Int[], Cdouble[],
+            true, true, Cdouble[], true, Dict{Symbol, Any}(kwargs))
+    end
+end
+SOI.SDSolverInstance(s::DSDPSolver) = DSDPSolverInstance(; s.options...)
+
+function SOI.initinstance!(m::DSDPSolverInstance, blkdims::Vector{Int}, nconstrs::Int)
+    @assert nconstrs >= 0
+    m.nconstrs = nconstrs
+    m.blkdims = blkdims
+    m.nlpdrows = 0
+    sdpidx = 0
+    m.blk = similar(blkdims)
+    for i in 1:length(blkdims)
+        if blkdims[i] < 0
+            m.blk[i] = m.nlpdrows
+            m.nlpdrows -= blkdims[i]
+        else
+            sdpidx += 1
+            m.blk[i] = sdpidx
+        end
+    end
+    m.lpdvars = Int[]
+    m.lpdrows = Int[]
+    m.lpcoefs = Cdouble[]
+    m.dsdp = Create(nconstrs)
+    # TODO only create if necessary
+    m.sdpcone = CreateSDPCone(m.dsdp, length(blkdims))
+    for constr in 1:nconstrs
+        # TODO in examples/readsdpa.c line 162,
+        # -0.0 is used instead of 0.0 if the dual obj is <= 0., check if it has impact
+        SetY0(m.dsdp, constr, 0.0)
+    end
+    # TODO ComputeY0 as in examples/readsdpa.c
+
+    m.x_computed = false
+    # m.y does not contain the solution y
+    m.y_valid = false
+    m.z_computed = false
+end
+
+function SOI.setconstraintconstant!(m::DSDPSolverInstance, val, constr::Integer)
+    SetDualObjective(m.dsdp, constr, val)
+end
+function _setcoefficient!(m::DSDPSolverInstance, coef, constr::Integer, blk::Integer, i::Integer, j::Integer)
+    if m.blkdims[blk] < 0
+        @assert i == j
+        push!(m.lpdvars, constr+1)
+        push!(m.lpdrows, m.blk[blk] + i - 1) # -1 because indexing starts at 0 in DSDP
+        push!(m.lpcoefs, coef)
+    else
+        error("TODO")
+    end
+end
+function SOI.setconstraintcoefficient!(m::DSDPSolverInstance, coef, constr::Integer, blk::Integer, i::Integer, j::Integer)
+    _setcoefficient!(m, coef, constr, blk, i, j)
+end
+function SOI.setobjectivecoefficient!(m::DSDPSolverInstance, coef, blk::Integer, i::Integer, j::Integer)
+    # in SOI, convention is MAX but in DSDP, convention is MIN so we reverse the sign of coef
+    _setcoefficient!(m, -coef, 0, blk, i, j)
+end
+
+function MOI.optimize!(m::DSDPSolverInstance)
+    if !isempty(m.lpdvars)
+        m.lpcone = CreateLPCone(m.dsdp)
+        LPCone.SetDataSparse(m.lpcone, m.nlpdrows, m.nconstrs+1, m.lpdvars, m.lpdrows, m.lpcoefs)
+    end
+
+    Setup(m.dsdp)
+    Solve(m.dsdp)
+
+    m.x_computed = false
+    # m.y does not contain the solution y
+    m.y_valid = false
+    m.z_computed = true
+end
+
+function MOI.get(m::DSDPSolverInstance, ::MOI.TerminationStatus)
+    status = StopReason(m.dsdp)
+    if status == DSDP_CONVERGED
+        return MOI.Success
+    elseif status == DSDP_INFEASIBLE_START
+        return MOI.OtherError
+    elseif status == DSDP_SMALL_STEPS
+        return MOI.SlowProgress
+    elseif status == DSDP_INDEFINITE_SCHUR_MATRIX
+        return MOI.NumericalError
+    elseif status == DSDP_MAX_IT
+        return MOI.IterationLimit
+    elseif status == DSDP_NUMERICAL_ERROR
+        return MOI.NumericalError
+    elseif status == DSDP_UPPERBOUND
+        return MOI.ObjectiveLimit
+    elseif status == DSDP_USER_TERMINATION
+        return MOI.Interrupted
+    elseif status == CONTINUE_ITERATING
+        return MOI.OtherError
+    else
+        error("Internal library error: status=$status")
+    end
+end
+
+MOI.canget(m::DSDPSolverInstance, ::MOI.PrimalStatus) = GetSolutionType(m.dsdp) != DSDP_PDUNKNOWN
+function MOI.get(m::DSDPSolverInstance, ::MOI.PrimalStatus)
+    compute_x(m)
+    status = GetSolutionType(m.dsdp)
+    if status == DSDP_PDUNKNOWN
+        return MOI.UnknownResultStatus
+    elseif status == DSDP_PDFEASIBLE
+        return MOI.FeasiblePoint
+    elseif status == DSDP_UNBOUNDED
+        return MOI.InfeasiblePoint
+    elseif status == DSDP_INFEASIBLE
+        return MOI.InfeasibilityCertificate
+    else
+        error("Internal library error: status=$status")
+    end
+end
+
+MOI.canget(m::DSDPSolverInstance, ::MOI.DualStatus) = GetSolutionType(m.dsdp) != DSDP_PDUNKNOWN
+function MOI.get(m::DSDPSolverInstance, ::MOI.DualStatus)
+    compute_x(m)
+    status = GetSolutionType(m.dsdp)
+    if status == DSDP_PDUNKNOWN
+        return MOI.UnknownResultStatus
+    elseif status == DSDP_PDFEASIBLE
+        return MOI.FeasiblePoint
+    elseif status == DSDP_UNBOUNDED
+        return MOI.InfeasibilityCertificate
+    elseif status == DSDP_INFEASIBLE
+        return MOI.InfeasiblePoint
+    else
+        error("Internal library error: status=$status")
+    end
+end
+
+function SOI.getprimalobjectivevalue(m::DSDPSolverInstance)
+    -GetPPObjective(m.dsdp)
+end
+function SOI.getdualobjectivevalue(m::DSDPSolverInstance)
+    -GetDDObjective(m.dsdp)
+end
+
+function compute_x(m::DSDPSolverInstance)
+    if !m.x_computed
+        ComputeX(m.dsdp)
+        m.x_computed = true
+        m.z_computed = false
+    end
+end
+struct LPXBlock <: AbstractMatrix{Cdouble}
+    lpcone::LPCone.LPConeT
+    offset::Int
+end
+function Base.getindex(x::LPXBlock, i, j)
+    if i == j
+        LPCone.GetXArray(x.lpcone)[x.offset+i]
+    else
+        zero(Cdouble)
+    end
+end
+struct XBlockMat <: AbstractMatrix{Cdouble}
+    instance::DSDPSolverInstance
+end
+function Base.getindex(x::XBlockMat, i)
+    compute_x(x.instance)
+    @assert x.instance.blkdims[i] < 0
+    LPXBlock(x.instance.lpcone, x.instance.blk[i])
+end
+function SOI.getX(m::DSDPSolverInstance)
+    XBlockMat(m)
+end
+
+function SOI.gety(m::DSDPSolverInstance)
+    if !m.y_valid
+        m.y = Vector{Cdouble}(m.nconstrs)
+        GetY(m.dsdp, m.y)
+        map!(-, m.y, m.y) # The primal objective is Max in SOI but Min in DSDP
+    end
+    m.y
+end
+
+function compute_z(m::DSDPSolverInstance)
+    if !m.z_computed
+        ComputeAndFactorS(m.dsdp)
+        m.z_computed = true
+    end
+end
+struct LPZBlock <: AbstractMatrix{Cdouble}
+    lpcone::LPCone.LPConeT
+    offset::Int
+end
+function Base.getindex(z::LPZBlock, i, j)
+    if i == j
+        LPCone.GetSArray(z.lpcone)[z.offset+i]
+    else
+        zero(Cdouble)
+    end
+end
+struct ZBlockMat <: AbstractMatrix{Cdouble}
+    instance::DSDPSolverInstance
+end
+function Base.getindex(z::ZBlockMat, i)
+    compute_z(z.instance)
+    @assert z.instance.blkdims[i] < 0
+    LPZBlock(z.instance.lpcone, z.instance.blk[i])
+end
+function SOI.getZ(m::DSDPSolverInstance)
+    ZBlockMat(m)
+end

--- a/src/bcone.jl
+++ b/src/bcone.jl
@@ -1,0 +1,44 @@
+export BCone
+
+module BCone
+
+import ..@dsdp_ccall
+const BConeT = Ptr{Void}
+
+function AllocateBounds(bcone::BConeT, arg2::Integer)
+    @dsdp_ccall BConeAllocateBounds (BConeT, Cint) bcone arg2
+end
+
+function SetLowerBound(bcone::BConeT, arg2::Integer, arg3::Cdouble)
+    @dsdp_ccall BConeSetLowerBound (BConeT, Cint, Cdouble) bcone arg2 arg3
+end
+
+function SetUpperBound(bcone::BConeT, arg2::Integer, arg3::Cdouble)
+    @dsdp_ccall BConeSetUpperBound (BConeT, Cint, Cdouble) bcone arg2 arg3
+end
+
+function SetPSlackVariable(bcone::BConeT, arg2::Integer)
+    @dsdp_ccall BConeSetPSlackVariable (BConeT, Cint) bcone arg2
+end
+
+function SetPSurplusVariable(bcone::BConeT, arg2::Integer)
+    @dsdp_ccall BConeSetPSurplusVariable (BConeT, Cint) bcone arg2
+end
+
+function ScaleBarrier(bcone::BConeT, arg2::Cdouble)
+    @dsdp_ccall BConeScaleBarrier (BConeT, Cdouble) bcone arg2
+end
+
+function View(bcone::BConeT)
+    @dsdp_ccall BConeView (BConeT,) bcone
+end
+
+function SetXArray(bcone::BConeT, arg2, arg3::Integer)
+    @dsdp_ccall BConeSetXArray (BConeT, Ptr{Cdouble}, Cint) bcone arg2 arg3
+end
+
+function CopyX(bcone::BConeT, arg2, arg3, arg4::Integer)
+    @dsdp_ccall BConeCopyX (BConeT, Ptr{Cdouble}, Ptr{Cdouble}, Cint) bcone arg2 arg3 arg4
+end
+
+end

--- a/src/dsdp5_API.jl
+++ b/src/dsdp5_API.jl
@@ -24,8 +24,10 @@ function ComputeX(dsdp::DSDPT)
     @dsdp_ccall DSDPComputeX (DSDPT,) dsdp
 end
 
-function ComputeAndFactorS(dsdp::DSDPT, arg2)
-    @dsdp_ccall DSDPComputeAndFactorS (DSDPT, Ptr{DSDPTruth}) dsdp arg2
+function ComputeAndFactorS(dsdp::DSDPT)
+    psdefinite = Ref{DSDPTruth}()
+    @dsdp_ccall DSDPComputeAndFactorS (DSDPT, Ref{DSDPTruth}) dsdp psdefinite
+    psdefinite[]
 end
 
 function Destroy(dsdp::DSDPT)
@@ -110,8 +112,8 @@ function SetY0(dsdp::DSDPT, arg2::Integer, arg3::Cdouble)
     @dsdp_ccall DSDPSetY0 (DSDPT, Cint, Cdouble) dsdp arg2 arg3
 end
 
-function GetY(dsdp::DSDPT, arg2, arg3::Integer)
-    @dsdp_ccall DSDPGetY (DSDPT, Ptr{Cdouble}, Cint) dsdp arg2 arg3
+function GetY(dsdp::DSDPT, y::Vector{Cdouble})
+    @dsdp_ccall DSDPGetY (DSDPT, Ptr{Cdouble}, Cint) dsdp pointer(y) length(y)
 end
 
 function GetYMakeX(dsdp::DSDPT, arg2, arg3::Integer)
@@ -212,8 +214,10 @@ function StopReason(dsdp::DSDPT)
     stop[]
 end
 
-function GetSolutionType(dsdp::DSDPT, arg2)
-    @dsdp_ccall DSDPGetSolutionType (DSDPT, Ptr{DSDPSolutionType}) dsdp arg2
+function GetSolutionType(dsdp::DSDPT)
+    sol = Ref{DSDPSolutionType}()
+    @dsdp_ccall DSDPGetSolutionType (DSDPT, Ref{DSDPSolutionType}) dsdp sol
+    sol[]
 end
 
 function SetPotentialParameter(dsdp::DSDPT, arg2::Real)

--- a/src/dsdp5_API.jl
+++ b/src/dsdp5_API.jl
@@ -2,39 +2,39 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function SetConvergenceFlag(dsdp::Ptr{Void}, arg2::DSDPTerminationReason)
-    ccall((:DSDPSetConvergenceFlag, libdsdp), Cint, (Ptr{Void}, DSDPTerminationReason), dsdp, arg2)
+function SetConvergenceFlag(dsdp::DSDPT, arg2::DSDPTerminationReason)
+    ccall((:DSDPSetConvergenceFlag, libdsdp), Cint, (DSDPT, DSDPTerminationReason), dsdp, arg2)
 end
 
 function Create(m::Integer)
-    dsdp = Ref{Ptr{Void}}()
-    info = ccall((:DSDPCreate, libdsdp), Cint, (Cint, Ref{Ptr{Void}}), m, dsdp)
+    dsdp = Ref{DSDPT}()
+    info = ccall((:DSDPCreate, libdsdp), Cint, (Cint, Ref{DSDPT}), m, dsdp)
     @assert iszero(info)
     dsdp[]
 end
 
-function Setup(dsdp::Ptr{Void})
-    ccall((:DSDPSetup, libdsdp), Cint, (Ptr{Void},), dsdp)
+function Setup(dsdp::DSDPT)
+    ccall((:DSDPSetup, libdsdp), Cint, (DSDPT,), dsdp)
 end
 
-function Solve(dsdp::Ptr{Void})
-    ccall((:DSDPSolve, libdsdp), Cint, (Ptr{Void},), dsdp)
+function Solve(dsdp::DSDPT)
+    ccall((:DSDPSolve, libdsdp), Cint, (DSDPT,), dsdp)
 end
 
-function ComputeX(dsdp::Ptr{Void})
-    ccall((:DSDPComputeX, libdsdp), Cint, (Ptr{Void},), dsdp)
+function ComputeX(dsdp::DSDPT)
+    ccall((:DSDPComputeX, libdsdp), Cint, (DSDPT,), dsdp)
 end
 
-function ComputeAndFactorS(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPComputeAndFactorS, libdsdp), Cint, (Ptr{Void}, Ptr{DSDPTruth}), dsdp, arg2)
+function ComputeAndFactorS(dsdp::DSDPT, arg2)
+    ccall((:DSDPComputeAndFactorS, libdsdp), Cint, (DSDPT, Ptr{DSDPTruth}), dsdp, arg2)
 end
 
-function Destroy(dsdp::Ptr{Void})
-    ccall((:DSDPDestroy, libdsdp), Cint, (Ptr{Void},), dsdp)
+function Destroy(dsdp::DSDPT)
+    ccall((:DSDPDestroy, libdsdp), Cint, (DSDPT,), dsdp)
 end
 
-function CreateBCone(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPCreateBCone, libdsdp), Cint, (Ptr{Void}, Ptr{BCone}), dsdp, arg2)
+function CreateBCone(dsdp::DSDPT, arg2)
+    ccall((:DSDPCreateBCone, libdsdp), Cint, (DSDPT, Ptr{BCone}), dsdp, arg2)
 end
 
 function BConeAllocateBounds(arg1::BCone, arg2::Integer)
@@ -73,20 +73,20 @@ function BConeCopyX(arg1::BCone, arg2, arg3, arg4::Integer)
     ccall((:BConeCopyX, libdsdp), Cint, (BCone, Ptr{Cdouble}, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4)
 end
 
-function BoundDualVariables(dsdp::Ptr{Void}, arg2::Cdouble, arg3::Cdouble)
-    ccall((:DSDPBoundDualVariables, libdsdp), Cint, (Ptr{Void}, Cdouble, Cdouble), dsdp, arg2, arg3)
+function BoundDualVariables(dsdp::DSDPT, arg2::Cdouble, arg3::Cdouble)
+    ccall((:DSDPBoundDualVariables, libdsdp), Cint, (DSDPT, Cdouble, Cdouble), dsdp, arg2, arg3)
 end
 
-function SetYBounds(dsdp::Ptr{Void}, arg2::Cdouble, arg3::Cdouble)
-    ccall((:DSDPSetYBounds, libdsdp), Cint, (Ptr{Void}, Cdouble, Cdouble), dsdp, arg2, arg3)
+function SetYBounds(dsdp::DSDPT, arg2::Cdouble, arg3::Cdouble)
+    ccall((:DSDPSetYBounds, libdsdp), Cint, (DSDPT, Cdouble, Cdouble), dsdp, arg2, arg3)
 end
 
-function GetYBounds(dsdp::Ptr{Void}, arg2, arg3)
-    ccall((:DSDPGetYBounds, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}), dsdp, arg2, arg3)
+function GetYBounds(dsdp::DSDPT, arg2, arg3)
+    ccall((:DSDPGetYBounds, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Ptr{Cdouble}), dsdp, arg2, arg3)
 end
 
-function CreateLPCone(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPCreateLPCone, libdsdp), Cint, (Ptr{Void}, Ptr{LPCone}), dsdp, arg2)
+function CreateLPCone(dsdp::DSDPT, arg2)
+    ccall((:DSDPCreateLPCone, libdsdp), Cint, (DSDPT, Ptr{LPCone}), dsdp, arg2)
 end
 
 function LPConeSetData(arg1::LPCone, arg2::Integer, arg3, arg4, arg5)
@@ -129,14 +129,14 @@ function LPConeCopyS(arg1::LPCone, arg2, arg3::Integer)
     ccall((:LPConeCopyS, libdsdp), Cint, (LPCone, Ptr{Cdouble}, Cint), arg1, arg2, arg3)
 end
 
-function CreateSDPCone(dsdp::Ptr{Void}, n::Integer)
+function CreateSDPCone(dsdp::DSDPT, n::Integer)
     sdpcone = Ref{SDPCone}()
-    info = ccall((:DSDPCreateSDPCone, libdsdp), Cint, (Ptr{Void}, Cint, Ref{SDPCone}), dsdp, n, sdpcone)
+    info = ccall((:DSDPCreateSDPCone, libdsdp), Cint, (DSDPT, Cint, Ref{SDPCone}), dsdp, n, sdpcone)
     @assert iszero(info)
     sdpcone[]
 end
-function CreateSDPCone(dsdp::Ptr{Void}, arg2::Integer, arg3)
-    ccall((:DSDPCreateSDPCone, libdsdp), Cint, (Ptr{Void}, Cint, Ptr{SDPCone}), dsdp, arg2, arg3)
+function CreateSDPCone(dsdp::DSDPT, arg2::Integer, arg3)
+    ccall((:DSDPCreateSDPCone, libdsdp), Cint, (DSDPT, Cint, Ptr{SDPCone}), dsdp, arg2, arg3)
 end
 
 function SDPConeSetBlockSize(sdpcone::SDPCone, i::Integer, j::Integer)
@@ -316,284 +316,284 @@ function SDPConeUseLAPACKForDualMatrix(arg1::SDPCone, arg2::Integer)
     ccall((:SDPConeUseLAPACKForDualMatrix, libdsdp), Cint, (SDPCone, Cint), arg1, arg2)
 end
 
-function SetDualObjective(dsdp::Ptr{Void}, arg2::Integer, arg3::Cdouble)
-    ccall((:DSDPSetDualObjective, libdsdp), Cint, (Ptr{Void}, Cint, Cdouble), dsdp, arg2, arg3)
+function SetDualObjective(dsdp::DSDPT, arg2::Integer, arg3::Cdouble)
+    ccall((:DSDPSetDualObjective, libdsdp), Cint, (DSDPT, Cint, Cdouble), dsdp, arg2, arg3)
 end
 
-function AddObjectiveConstant(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPAddObjectiveConstant, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function AddObjectiveConstant(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPAddObjectiveConstant, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetDObjective(dsdp::Ptr{Void})
+function GetDObjective(dsdp::DSDPT)
     dobj = Ref{Cdouble}()
-    ccall((:DSDPGetDObjective, libdsdp), Cint, (Ptr{Void}, Ref{Cdouble}), dsdp, dobj)
+    ccall((:DSDPGetDObjective, libdsdp), Cint, (DSDPT, Ref{Cdouble}), dsdp, dobj)
     dobj[]
 end
 
-function GetDDObjective(dsdp::Ptr{Void})
+function GetDDObjective(dsdp::DSDPT)
     ddobj = Ref{Cdouble}()
-    ccall((:DSDPGetDDObjective, libdsdp), Cint, (Ptr{Void}, Ref{Cdouble}), dsdp, ddobj)
+    ccall((:DSDPGetDDObjective, libdsdp), Cint, (DSDPT, Ref{Cdouble}), dsdp, ddobj)
     ddobj[]
 end
 
-function GetPObjective(dsdp::Ptr{Void})
+function GetPObjective(dsdp::DSDPT)
     pobj = Ref{Cdouble}()
-    ccall((:DSDPGetPObjective, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, pobj)
+    ccall((:DSDPGetPObjective, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, pobj)
     pobj[]
 end
 
-function GetPPObjective(dsdp::Ptr{Void})
+function GetPPObjective(dsdp::DSDPT)
     ppobj = Ref{Cdouble}()
-    ccall((:DSDPGetPPObjective, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, ppobj)
+    ccall((:DSDPGetPPObjective, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, ppobj)
     ppobj[]
 end
 
-function GetDualityGap(dsdp::Ptr{Void})
+function GetDualityGap(dsdp::DSDPT)
     dgap = Ref{Cdouble}()
-    ccall((:DSDPGetDualityGap, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, dgap)
+    ccall((:DSDPGetDualityGap, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, dgap)
     dgap[]
 end
 
-function GetScale(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetScale, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetScale(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetScale, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetScale(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetScale, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetScale(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetScale, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetPenaltyParameter(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetPenaltyParameter, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetPenaltyParameter(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetPenaltyParameter, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function GetPenalty(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetPenalty, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetPenalty(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetPenalty, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function CopyB(dsdp::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPCopyB, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+function CopyB(dsdp::DSDPT, arg2, arg3::Integer)
+    ccall((:DSDPCopyB, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function SetR0(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetR0, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetR0(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetR0, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetR(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetR, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetR(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetR, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetRTolerance(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetRTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetRTolerance(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetRTolerance, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetRTolerance(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetRTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetRTolerance(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetRTolerance, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetY0(dsdp::Ptr{Void}, arg2::Integer, arg3::Cdouble)
-    ccall((:DSDPSetY0, libdsdp), Cint, (Ptr{Void}, Cint, Cdouble), dsdp, arg2, arg3)
+function SetY0(dsdp::DSDPT, arg2::Integer, arg3::Cdouble)
+    ccall((:DSDPSetY0, libdsdp), Cint, (DSDPT, Cint, Cdouble), dsdp, arg2, arg3)
 end
 
-function GetY(dsdp::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPGetY, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+function GetY(dsdp::DSDPT, arg2, arg3::Integer)
+    ccall((:DSDPGetY, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function GetYMakeX(dsdp::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPGetYMakeX, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+function GetYMakeX(dsdp::DSDPT, arg2, arg3::Integer)
+    ccall((:DSDPGetYMakeX, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function GetDYMakeX(dsdp::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPGetDYMakeX, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+function GetDYMakeX(dsdp::DSDPT, arg2, arg3::Integer)
+    ccall((:DSDPGetDYMakeX, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function GetMuMakeX(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetMuMakeX, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetMuMakeX(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetMuMakeX, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function GetBarrierParameter(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetBarrierParameter, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetBarrierParameter(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetBarrierParameter, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetBarrierParameter(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetBarrierParameter, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetBarrierParameter(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetBarrierParameter, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function ReuseMatrix(dsdp::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPReuseMatrix, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
+function ReuseMatrix(dsdp::DSDPT, arg2::Integer)
+    ccall((:DSDPReuseMatrix, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
 end
 
-function GetReuseMatrix(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetReuseMatrix, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), dsdp, arg2)
+function GetReuseMatrix(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetReuseMatrix, libdsdp), Cint, (DSDPT, Ptr{Cint}), dsdp, arg2)
 end
 
-function GetDimension(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetDimension, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetDimension(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetDimension, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetMaxIts(dsdp::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPSetMaxIts, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
+function SetMaxIts(dsdp::DSDPT, arg2::Integer)
+    ccall((:DSDPSetMaxIts, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
 end
 
-function GetMaxIts(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetMaxIts, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), dsdp, arg2)
+function GetMaxIts(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetMaxIts, libdsdp), Cint, (DSDPT, Ptr{Cint}), dsdp, arg2)
 end
 
-function SetStepTolerance(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetStepTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetStepTolerance(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetStepTolerance, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetStepTolerance(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetStepTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetStepTolerance(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetStepTolerance, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetGapTolerance(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetGapTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetGapTolerance(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetGapTolerance, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetGapTolerance(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetGapTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetGapTolerance(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetGapTolerance, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetPNormTolerance(dsdp::Ptr{Void}, arg2::Real)
-    ccall((:DSDPSetPNormTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetPNormTolerance(dsdp::DSDPT, arg2::Real)
+    ccall((:DSDPSetPNormTolerance, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetPNormTolerance(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetPNormTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetPNormTolerance(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetPNormTolerance, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetDualBound(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetDualBound, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetDualBound(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetDualBound, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetDualBound(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetDualBound, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetDualBound(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetDualBound, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetPTolerance(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetPTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetPTolerance(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetPTolerance, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetPTolerance(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetPTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetPTolerance(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetPTolerance, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function GetPInfeasibility(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetPInfeasibility, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetPInfeasibility(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetPInfeasibility, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetMaxTrustRadius(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetMaxTrustRadius, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetMaxTrustRadius(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetMaxTrustRadius, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetMaxTrustRadius(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetMaxTrustRadius, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetMaxTrustRadius(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetMaxTrustRadius, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function StopReason(dsdp::Ptr{Void})
+function StopReason(dsdp::DSDPT)
     stop = Ref{DSDPTerminationReason}()
-    ccall((:DSDPStopReason, libdsdp), Cint, (Ptr{Void}, Ref{DSDPTerminationReason}), dsdp, stop)
+    ccall((:DSDPStopReason, libdsdp), Cint, (DSDPT, Ref{DSDPTerminationReason}), dsdp, stop)
     stop[]
 end
 
-function GetSolutionType(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetSolutionType, libdsdp), Cint, (Ptr{Void}, Ptr{DSDPSolutionType}), dsdp, arg2)
+function GetSolutionType(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetSolutionType, libdsdp), Cint, (DSDPT, Ptr{DSDPSolutionType}), dsdp, arg2)
 end
 
-function SetPotentialParameter(dsdp::Ptr{Void}, arg2::Real)
-    ccall((:DSDPSetPotentialParameter, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetPotentialParameter(dsdp::DSDPT, arg2::Real)
+    ccall((:DSDPSetPotentialParameter, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetPotentialParameter(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetPotentialParameter, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetPotentialParameter(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetPotentialParameter, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function UseDynamicRho(dsdp::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPUseDynamicRho, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
+function UseDynamicRho(dsdp::DSDPT, arg2::Integer)
+    ccall((:DSDPUseDynamicRho, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
 end
 
-function GetPotential(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetPotential, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetPotential(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetPotential, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function UseLAPACKForSchur(dsdp::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPUseLAPACKForSchur, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
+function UseLAPACKForSchur(dsdp::DSDPT, arg2::Integer)
+    ccall((:DSDPUseLAPACKForSchur, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
 end
 
-function GetNumberOfVariables(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetNumberOfVariables, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), dsdp, arg2)
+function GetNumberOfVariables(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetNumberOfVariables, libdsdp), Cint, (DSDPT, Ptr{Cint}), dsdp, arg2)
 end
 
-function GetFinalErrors(dsdp::Ptr{Void}, arg2::NTuple{6, Cdouble})
-    ccall((:DSDPGetFinalErrors, libdsdp), Cint, (Ptr{Void}, NTuple{6, Cdouble}), dsdp, arg2)
+function GetFinalErrors(dsdp::DSDPT, arg2::NTuple{6, Cdouble})
+    ccall((:DSDPGetFinalErrors, libdsdp), Cint, (DSDPT, NTuple{6, Cdouble}), dsdp, arg2)
 end
 
-function GetGapHistory(dsdp::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPGetGapHistory, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+function GetGapHistory(dsdp::DSDPT, arg2, arg3::Integer)
+    ccall((:DSDPGetGapHistory, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function GetRHistory(dsdp::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPGetRHistory, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+function GetRHistory(dsdp::DSDPT, arg2, arg3::Integer)
+    ccall((:DSDPGetRHistory, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function GetIts(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetIts, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), dsdp, arg2)
+function GetIts(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetIts, libdsdp), Cint, (DSDPT, Ptr{Cint}), dsdp, arg2)
 end
 
-function GetPnorm(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetPnorm, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetPnorm(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetPnorm, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function GetStepLengths(dsdp::Ptr{Void}, arg2, arg3)
-    ccall((:DSDPGetStepLengths, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}), dsdp, arg2, arg3)
+function GetStepLengths(dsdp::DSDPT, arg2, arg3)
+    ccall((:DSDPGetStepLengths, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Ptr{Cdouble}), dsdp, arg2, arg3)
 end
 
-function SetMonitor(dsdp::Ptr{Void}, arg2, arg3)
-    ccall((:DSDPSetMonitor, libdsdp), Cint, (Ptr{Void}, Ptr{Void}, Ptr{Void}), dsdp, arg2, arg3)
+function SetMonitor(dsdp::DSDPT, arg2, arg3)
+    ccall((:DSDPSetMonitor, libdsdp), Cint, (DSDPT, DSDPT, DSDPT), dsdp, arg2, arg3)
 end
 
-function SetStandardMonitor(dsdp::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPSetStandardMonitor, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
+function SetStandardMonitor(dsdp::DSDPT, arg2::Integer)
+    ccall((:DSDPSetStandardMonitor, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
 end
 
-function SetFileMonitor(dsdp::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPSetFileMonitor, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
+function SetFileMonitor(dsdp::DSDPT, arg2::Integer)
+    ccall((:DSDPSetFileMonitor, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
 end
 
-function SetPenaltyParameter(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetPenaltyParameter, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetPenaltyParameter(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetPenaltyParameter, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function UsePenalty(dsdp::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPUsePenalty, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
+function UsePenalty(dsdp::DSDPT, arg2::Integer)
+    ccall((:DSDPUsePenalty, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
 end
 
 function PrintLogInfo(arg1::Integer)
     ccall((:DSDPPrintLogInfo, libdsdp), Cint, (Cint,), arg1)
 end
 
-function ComputeMinimumXEigenvalue(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPComputeMinimumXEigenvalue, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function ComputeMinimumXEigenvalue(dsdp::DSDPT, arg2)
+    ccall((:DSDPComputeMinimumXEigenvalue, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function GetTraceX(dsdp::Ptr{Void}, arg1)
-    ccall((:DSDPGetTraceX, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg1)
+function GetTraceX(dsdp::DSDPT, arg1)
+    ccall((:DSDPGetTraceX, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg1)
 end
 
-function SetZBar(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetZBar, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetZBar(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetZBar, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function SetDualLowerBound(dsdp::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetDualLowerBound, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
+function SetDualLowerBound(dsdp::DSDPT, arg2::Cdouble)
+    ccall((:DSDPSetDualLowerBound, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
 end
 
-function GetDataNorms(dsdp::Ptr{Void}, arg2::NTuple{3, Cdouble})
-    ccall((:DSDPGetDataNorms, libdsdp), Cint, (Ptr{Void}, NTuple{3, Cdouble}), dsdp, arg2)
+function GetDataNorms(dsdp::DSDPT, arg2::NTuple{3, Cdouble})
+    ccall((:DSDPGetDataNorms, libdsdp), Cint, (DSDPT, NTuple{3, Cdouble}), dsdp, arg2)
 end
 
-function GetYMaxNorm(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPGetYMaxNorm, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
+function GetYMaxNorm(dsdp::DSDPT, arg2)
+    ccall((:DSDPGetYMaxNorm, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
 end
 
 function SDPConeUseFullSymmetricFormat(arg1::SDPCone, arg2::Integer)
@@ -604,42 +604,42 @@ function SDPConeUsePackedFormat(arg1::SDPCone, arg2::Integer)
     ccall((:SDPConeUsePackedFormat, libdsdp), Cint, (SDPCone, Cint), arg1, arg2)
 end
 
-function SetFixedVariable(dsdp::Ptr{Void}, arg2::Integer, arg3::Cdouble)
-    ccall((:DSDPSetFixedVariable, libdsdp), Cint, (Ptr{Void}, Cint, Cdouble), dsdp, arg2, arg3)
+function SetFixedVariable(dsdp::DSDPT, arg2::Integer, arg3::Cdouble)
+    ccall((:DSDPSetFixedVariable, libdsdp), Cint, (DSDPT, Cint, Cdouble), dsdp, arg2, arg3)
 end
 
-function SetFixedVariables(dsdp::Ptr{Void}, arg2, arg3, arg4, arg5::Integer)
-    ccall((:DSDPSetFixedVariables, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3, arg4, arg5)
+function SetFixedVariables(dsdp::DSDPT, arg2, arg3, arg4, arg5::Integer)
+    ccall((:DSDPSetFixedVariables, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3, arg4, arg5)
 end
 
-function GetFixedYX(dsdp::Ptr{Void}, arg2::Integer, arg3)
-    ccall((:DSDPGetFixedYX, libdsdp), Cint, (Ptr{Void}, Cint, Ptr{Cdouble}), dsdp, arg2, arg3)
+function GetFixedYX(dsdp::DSDPT, arg2::Integer, arg3)
+    ccall((:DSDPGetFixedYX, libdsdp), Cint, (DSDPT, Cint, Ptr{Cdouble}), dsdp, arg2, arg3)
 end
 
-function View(dsdp::Ptr{Void})
-    ccall((:DSDPView, libdsdp), Cint, (Ptr{Void},), dsdp)
+function View(dsdp::DSDPT)
+    ccall((:DSDPView, libdsdp), Cint, (DSDPT,), dsdp)
 end
 
 function PrintOptions()
     ccall((:DSDPPrintOptions, libdsdp), Cint, ())
 end
 
-function PrintData(dsdp::Ptr{Void}, arg2::SDPCone, arg3::LPCone)
-    ccall((:DSDPPrintData, libdsdp), Cint, (Ptr{Void}, SDPCone, LPCone), dsdp, arg2, arg3)
+function PrintData(dsdp::DSDPT, arg2::SDPCone, arg3::LPCone)
+    ccall((:DSDPPrintData, libdsdp), Cint, (DSDPT, SDPCone, LPCone), dsdp, arg2, arg3)
 end
 
-#function PrintSolution(arg1, arg2::Ptr{Void}, arg3::SDPCone, arg4::LPCone)
+#function PrintSolution(arg1, arg2::DSDPT, arg3::SDPCone, arg4::LPCone)
 #    ccall((:DSDPPrintSolution, libdsdp), Cint, (Ptr{FILE}, DSDP, SDPCone, LPCone), arg1, arg2, arg3, arg4)
 #end
 
-function SetOptions(dsdp::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPSetOptions, libdsdp), Cint, (Ptr{Void}, Ptr{Cstring}, Cint), dsdp, arg2, arg3)
+function SetOptions(dsdp::DSDPT, arg2, arg3::Integer)
+    ccall((:DSDPSetOptions, libdsdp), Cint, (DSDPT, Ptr{Cstring}, Cint), dsdp, arg2, arg3)
 end
 
-function ReadOptions(dsdp::Ptr{Void}, arg2)
-    ccall((:DSDPReadOptions, libdsdp), Cint, (Ptr{Void}, Ptr{UInt8}), dsdp, arg2)
+function ReadOptions(dsdp::DSDPT, arg2)
+    ccall((:DSDPReadOptions, libdsdp), Cint, (DSDPT, Ptr{UInt8}), dsdp, arg2)
 end
 
-function SetDestroyRoutine(dsdp::Ptr{Void}, arg2, arg3)
-    ccall((:DSDPSetDestroyRoutine, libdsdp), Cint, (Ptr{Void}, Ptr{Void}, Ptr{Void}), dsdp, arg2, arg3)
+function SetDestroyRoutine(dsdp::DSDPT, arg2, arg3)
+    ccall((:DSDPSetDestroyRoutine, libdsdp), Cint, (DSDPT, DSDPT, DSDPT), dsdp, arg2, arg3)
 end

--- a/src/dsdp5_API.jl
+++ b/src/dsdp5_API.jl
@@ -2,8 +2,8 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function SetConvergenceFlag(arg1::Ptr{Void}, arg2::DSDPTerminationReason)
-    ccall((:DSDPSetConvergenceFlag, libdsdp), Cint, (Ptr{Void}, DSDPTerminationReason), arg1, arg2)
+function SetConvergenceFlag(dsdp::Ptr{Void}, arg2::DSDPTerminationReason)
+    ccall((:DSDPSetConvergenceFlag, libdsdp), Cint, (Ptr{Void}, DSDPTerminationReason), dsdp, arg2)
 end
 
 function Create(m::Integer)
@@ -21,20 +21,20 @@ function Solve(dsdp::Ptr{Void})
     ccall((:DSDPSolve, libdsdp), Cint, (Ptr{Void},), dsdp)
 end
 
-function ComputeX(arg1::Ptr{Void})
-    ccall((:DSDPComputeX, libdsdp), Cint, (Ptr{Void},), arg1)
+function ComputeX(dsdp::Ptr{Void})
+    ccall((:DSDPComputeX, libdsdp), Cint, (Ptr{Void},), dsdp)
 end
 
-function ComputeAndFactorS(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPComputeAndFactorS, libdsdp), Cint, (Ptr{Void}, Ptr{DSDPTruth}), arg1, arg2)
+function ComputeAndFactorS(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPComputeAndFactorS, libdsdp), Cint, (Ptr{Void}, Ptr{DSDPTruth}), dsdp, arg2)
 end
 
-function Destroy(arg1::Ptr{Void})
-    ccall((:DSDPDestroy, libdsdp), Cint, (Ptr{Void},), arg1)
+function Destroy(dsdp::Ptr{Void})
+    ccall((:DSDPDestroy, libdsdp), Cint, (Ptr{Void},), dsdp)
 end
 
-function CreateBCone(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPCreateBCone, libdsdp), Cint, (Ptr{Void}, Ptr{BCone}), arg1, arg2)
+function CreateBCone(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPCreateBCone, libdsdp), Cint, (Ptr{Void}, Ptr{BCone}), dsdp, arg2)
 end
 
 function BConeAllocateBounds(arg1::BCone, arg2::Integer)
@@ -73,20 +73,20 @@ function BConeCopyX(arg1::BCone, arg2, arg3, arg4::Integer)
     ccall((:BConeCopyX, libdsdp), Cint, (BCone, Ptr{Cdouble}, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4)
 end
 
-function BoundDualVariables(arg1::Ptr{Void}, arg2::Cdouble, arg3::Cdouble)
-    ccall((:DSDPBoundDualVariables, libdsdp), Cint, (Ptr{Void}, Cdouble, Cdouble), arg1, arg2, arg3)
+function BoundDualVariables(dsdp::Ptr{Void}, arg2::Cdouble, arg3::Cdouble)
+    ccall((:DSDPBoundDualVariables, libdsdp), Cint, (Ptr{Void}, Cdouble, Cdouble), dsdp, arg2, arg3)
 end
 
-function SetYBounds(arg1::Ptr{Void}, arg2::Cdouble, arg3::Cdouble)
-    ccall((:DSDPSetYBounds, libdsdp), Cint, (Ptr{Void}, Cdouble, Cdouble), arg1, arg2, arg3)
+function SetYBounds(dsdp::Ptr{Void}, arg2::Cdouble, arg3::Cdouble)
+    ccall((:DSDPSetYBounds, libdsdp), Cint, (Ptr{Void}, Cdouble, Cdouble), dsdp, arg2, arg3)
 end
 
-function GetYBounds(arg1::Ptr{Void}, arg2, arg3)
-    ccall((:DSDPGetYBounds, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}), arg1, arg2, arg3)
+function GetYBounds(dsdp::Ptr{Void}, arg2, arg3)
+    ccall((:DSDPGetYBounds, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}), dsdp, arg2, arg3)
 end
 
-function CreateLPCone(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPCreateLPCone, libdsdp), Cint, (Ptr{Void}, Ptr{LPCone}), arg1, arg2)
+function CreateLPCone(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPCreateLPCone, libdsdp), Cint, (Ptr{Void}, Ptr{LPCone}), dsdp, arg2)
 end
 
 function LPConeSetData(arg1::LPCone, arg2::Integer, arg3, arg4, arg5)
@@ -135,8 +135,8 @@ function CreateSDPCone(dsdp::Ptr{Void}, n::Integer)
     @assert iszero(info)
     sdpcone[]
 end
-function CreateSDPCone(arg1::Ptr{Void}, arg2::Integer, arg3)
-    ccall((:DSDPCreateSDPCone, libdsdp), Cint, (Ptr{Void}, Cint, Ptr{SDPCone}), arg1, arg2, arg3)
+function CreateSDPCone(dsdp::Ptr{Void}, arg2::Integer, arg3)
+    ccall((:DSDPCreateSDPCone, libdsdp), Cint, (Ptr{Void}, Cint, Ptr{SDPCone}), dsdp, arg2, arg3)
 end
 
 function SDPConeSetBlockSize(sdpcone::SDPCone, i::Integer, j::Integer)
@@ -296,184 +296,198 @@ function SDPConeScaleBarrier(arg1::SDPCone, arg2::Integer, arg3::Cdouble)
     ccall((:SDPConeScaleBarrier, libdsdp), Cint, (SDPCone, Cint, Cdouble), arg1, arg2, arg3)
 end
 
-function SDPConeXVMultiply(arg1::SDPCone, arg2::Integer, arg3, arg4, arg5::Integer)
-    ccall((:SDPConeXVMultiply, libdsdp), Cint, (SDPCone, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5)
+function SDPConeXVMultiply(sdpcone::SDPCone, arg2::Integer, arg3::Vector, arg4::Vector)
+    n = length(arg3)
+    @assert n == length(arg4)
+    ccall((:SDPConeXVMultiply, libdsdp), Cint, (SDPCone, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), sdpcone, arg2, pointer(arg3), pointer(arg4), n)
 end
 
-function SDPConeComputeXV(arg1::SDPCone, arg2::Integer, arg3)
-    ccall((:SDPConeComputeXV, libdsdp), Cint, (SDPCone, Cint, Ptr{Cint}), arg1, arg2, arg3)
+function SDPConeComputeXV(sdpcone::SDPCone, arg2::Integer)
+    derror = Ref{Cint}()
+    ccall((:SDPConeComputeXV, libdsdp), Cint, (SDPCone, Cint, Ref{Cint}), sdpcone, arg2, derror)
+    derror[]
 end
 
-function SDPConeAddXVAV(arg1::SDPCone, arg2::Integer, arg3, arg4::Integer, arg5, arg6::Integer)
-    ccall((:SDPConeAddXVAV, libdsdp), Cint, (SDPCone, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6)
+function SDPConeAddXVAV(arg1::SDPCone, arg2::Integer, arg3::Vector, arg5::Vector)
+    ccall((:SDPConeAddXVAV, libdsdp), Cint, (SDPCone, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), arg1, arg2, pointer(arg3), length(arg3), pointer(arg5), length(arg5))
 end
 
 function SDPConeUseLAPACKForDualMatrix(arg1::SDPCone, arg2::Integer)
     ccall((:SDPConeUseLAPACKForDualMatrix, libdsdp), Cint, (SDPCone, Cint), arg1, arg2)
 end
 
-function SetDualObjective(arg1::Ptr{Void}, arg2::Integer, arg3::Cdouble)
-    ccall((:DSDPSetDualObjective, libdsdp), Cint, (Ptr{Void}, Cint, Cdouble), arg1, arg2, arg3)
+function SetDualObjective(dsdp::Ptr{Void}, arg2::Integer, arg3::Cdouble)
+    ccall((:DSDPSetDualObjective, libdsdp), Cint, (Ptr{Void}, Cint, Cdouble), dsdp, arg2, arg3)
 end
 
-function AddObjectiveConstant(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPAddObjectiveConstant, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function AddObjectiveConstant(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPAddObjectiveConstant, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetDObjective(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetDObjective, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetDObjective(dsdp::Ptr{Void})
+    dobj = Ref{Cdouble}()
+    ccall((:DSDPGetDObjective, libdsdp), Cint, (Ptr{Void}, Ref{Cdouble}), dsdp, dobj)
+    dobj[]
 end
 
-function GetDDObjective(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetDDObjective, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetDDObjective(dsdp::Ptr{Void})
+    ddobj = Ref{Cdouble}()
+    ccall((:DSDPGetDDObjective, libdsdp), Cint, (Ptr{Void}, Ref{Cdouble}), dsdp, ddobj)
+    ddobj[]
 end
 
-function GetPObjective(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetPObjective, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetPObjective(dsdp::Ptr{Void})
+    pobj = Ref{Cdouble}()
+    ccall((:DSDPGetPObjective, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, pobj)
+    pobj[]
 end
 
-function GetPPObjective(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetPPObjective, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetPPObjective(dsdp::Ptr{Void})
+    ppobj = Ref{Cdouble}()
+    ccall((:DSDPGetPPObjective, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, ppobj)
+    ppobj[]
 end
 
-function GetDualityGap(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetDualityGap, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetDualityGap(dsdp::Ptr{Void})
+    dgap = Ref{Cdouble}()
+    ccall((:DSDPGetDualityGap, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, dgap)
+    dgap[]
 end
 
-function GetScale(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetScale, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetScale(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetScale, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetScale(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetScale, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetScale(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetScale, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetPenaltyParameter(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetPenaltyParameter, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetPenaltyParameter(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetPenaltyParameter, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function GetPenalty(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetPenalty, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetPenalty(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetPenalty, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function CopyB(arg1::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPCopyB, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), arg1, arg2, arg3)
+function CopyB(dsdp::Ptr{Void}, arg2, arg3::Integer)
+    ccall((:DSDPCopyB, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function SetR0(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetR0, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetR0(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetR0, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetR(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetR, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetR(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetR, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetRTolerance(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetRTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetRTolerance(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetRTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetRTolerance(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetRTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetRTolerance(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetRTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetY0(arg1::Ptr{Void}, arg2::Integer, arg3::Cdouble)
-    ccall((:DSDPSetY0, libdsdp), Cint, (Ptr{Void}, Cint, Cdouble), arg1, arg2, arg3)
+function SetY0(dsdp::Ptr{Void}, arg2::Integer, arg3::Cdouble)
+    ccall((:DSDPSetY0, libdsdp), Cint, (Ptr{Void}, Cint, Cdouble), dsdp, arg2, arg3)
 end
 
-function GetY(arg1::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPGetY, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), arg1, arg2, arg3)
+function GetY(dsdp::Ptr{Void}, arg2, arg3::Integer)
+    ccall((:DSDPGetY, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function GetYMakeX(arg1::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPGetYMakeX, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), arg1, arg2, arg3)
+function GetYMakeX(dsdp::Ptr{Void}, arg2, arg3::Integer)
+    ccall((:DSDPGetYMakeX, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function GetDYMakeX(arg1::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPGetDYMakeX, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), arg1, arg2, arg3)
+function GetDYMakeX(dsdp::Ptr{Void}, arg2, arg3::Integer)
+    ccall((:DSDPGetDYMakeX, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function GetMuMakeX(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetMuMakeX, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetMuMakeX(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetMuMakeX, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function GetBarrierParameter(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetBarrierParameter, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetBarrierParameter(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetBarrierParameter, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetBarrierParameter(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetBarrierParameter, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetBarrierParameter(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetBarrierParameter, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function ReuseMatrix(arg1::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPReuseMatrix, libdsdp), Cint, (Ptr{Void}, Cint), arg1, arg2)
+function ReuseMatrix(dsdp::Ptr{Void}, arg2::Integer)
+    ccall((:DSDPReuseMatrix, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
 end
 
-function GetReuseMatrix(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetReuseMatrix, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), arg1, arg2)
+function GetReuseMatrix(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetReuseMatrix, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), dsdp, arg2)
 end
 
-function GetDimension(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetDimension, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetDimension(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetDimension, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetMaxIts(arg1::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPSetMaxIts, libdsdp), Cint, (Ptr{Void}, Cint), arg1, arg2)
+function SetMaxIts(dsdp::Ptr{Void}, arg2::Integer)
+    ccall((:DSDPSetMaxIts, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
 end
 
-function GetMaxIts(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetMaxIts, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), arg1, arg2)
+function GetMaxIts(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetMaxIts, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), dsdp, arg2)
 end
 
-function SetStepTolerance(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetStepTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetStepTolerance(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetStepTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetStepTolerance(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetStepTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetStepTolerance(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetStepTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetGapTolerance(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetGapTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetGapTolerance(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetGapTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetGapTolerance(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetGapTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetGapTolerance(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetGapTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
 function SetPNormTolerance(dsdp::Ptr{Void}, arg2::Real)
     ccall((:DSDPSetPNormTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetPNormTolerance(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetPNormTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetPNormTolerance(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetPNormTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetDualBound(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetDualBound, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetDualBound(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetDualBound, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetDualBound(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetDualBound, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetDualBound(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetDualBound, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetPTolerance(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetPTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetPTolerance(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetPTolerance, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetPTolerance(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetPTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetPTolerance(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetPTolerance, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function GetPInfeasibility(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetPInfeasibility, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetPInfeasibility(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetPInfeasibility, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function SetMaxTrustRadius(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetMaxTrustRadius, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetMaxTrustRadius(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetMaxTrustRadius, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetMaxTrustRadius(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetMaxTrustRadius, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetMaxTrustRadius(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetMaxTrustRadius, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
 function StopReason(dsdp::Ptr{Void})
@@ -482,104 +496,104 @@ function StopReason(dsdp::Ptr{Void})
     stop[]
 end
 
-function GetSolutionType(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetSolutionType, libdsdp), Cint, (Ptr{Void}, Ptr{DSDPSolutionType}), arg1, arg2)
+function GetSolutionType(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetSolutionType, libdsdp), Cint, (Ptr{Void}, Ptr{DSDPSolutionType}), dsdp, arg2)
 end
 
-function SetPotentialParameter(arg1::Ptr{Void}, arg2::Real)
-    ccall((:DSDPSetPotentialParameter, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetPotentialParameter(dsdp::Ptr{Void}, arg2::Real)
+    ccall((:DSDPSetPotentialParameter, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetPotentialParameter(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetPotentialParameter, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetPotentialParameter(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetPotentialParameter, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function UseDynamicRho(arg1::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPUseDynamicRho, libdsdp), Cint, (Ptr{Void}, Cint), arg1, arg2)
+function UseDynamicRho(dsdp::Ptr{Void}, arg2::Integer)
+    ccall((:DSDPUseDynamicRho, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
 end
 
-function GetPotential(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetPotential, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetPotential(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetPotential, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function UseLAPACKForSchur(arg1::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPUseLAPACKForSchur, libdsdp), Cint, (Ptr{Void}, Cint), arg1, arg2)
+function UseLAPACKForSchur(dsdp::Ptr{Void}, arg2::Integer)
+    ccall((:DSDPUseLAPACKForSchur, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
 end
 
-function GetNumberOfVariables(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetNumberOfVariables, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), arg1, arg2)
+function GetNumberOfVariables(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetNumberOfVariables, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), dsdp, arg2)
 end
 
-function GetFinalErrors(arg1::Ptr{Void}, arg2::NTuple{6, Cdouble})
-    ccall((:DSDPGetFinalErrors, libdsdp), Cint, (Ptr{Void}, NTuple{6, Cdouble}), arg1, arg2)
+function GetFinalErrors(dsdp::Ptr{Void}, arg2::NTuple{6, Cdouble})
+    ccall((:DSDPGetFinalErrors, libdsdp), Cint, (Ptr{Void}, NTuple{6, Cdouble}), dsdp, arg2)
 end
 
-function GetGapHistory(arg1::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPGetGapHistory, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), arg1, arg2, arg3)
+function GetGapHistory(dsdp::Ptr{Void}, arg2, arg3::Integer)
+    ccall((:DSDPGetGapHistory, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function GetRHistory(arg1::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPGetRHistory, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), arg1, arg2, arg3)
+function GetRHistory(dsdp::Ptr{Void}, arg2, arg3::Integer)
+    ccall((:DSDPGetRHistory, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
 end
 
-function GetIts(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetIts, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), arg1, arg2)
+function GetIts(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetIts, libdsdp), Cint, (Ptr{Void}, Ptr{Cint}), dsdp, arg2)
 end
 
-function GetPnorm(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetPnorm, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetPnorm(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetPnorm, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
-function GetStepLengths(arg1::Ptr{Void}, arg2, arg3)
-    ccall((:DSDPGetStepLengths, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}), arg1, arg2, arg3)
+function GetStepLengths(dsdp::Ptr{Void}, arg2, arg3)
+    ccall((:DSDPGetStepLengths, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}), dsdp, arg2, arg3)
 end
 
-function SetMonitor(arg1::Ptr{Void}, arg2, arg3)
-    ccall((:DSDPSetMonitor, libdsdp), Cint, (Ptr{Void}, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3)
+function SetMonitor(dsdp::Ptr{Void}, arg2, arg3)
+    ccall((:DSDPSetMonitor, libdsdp), Cint, (Ptr{Void}, Ptr{Void}, Ptr{Void}), dsdp, arg2, arg3)
 end
 
 function SetStandardMonitor(dsdp::Ptr{Void}, arg2::Integer)
     ccall((:DSDPSetStandardMonitor, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
 end
 
-function SetFileMonitor(arg1::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPSetFileMonitor, libdsdp), Cint, (Ptr{Void}, Cint), arg1, arg2)
+function SetFileMonitor(dsdp::Ptr{Void}, arg2::Integer)
+    ccall((:DSDPSetFileMonitor, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
 end
 
-function SetPenaltyParameter(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetPenaltyParameter, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetPenaltyParameter(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetPenaltyParameter, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function UsePenalty(arg1::Ptr{Void}, arg2::Integer)
-    ccall((:DSDPUsePenalty, libdsdp), Cint, (Ptr{Void}, Cint), arg1, arg2)
+function UsePenalty(dsdp::Ptr{Void}, arg2::Integer)
+    ccall((:DSDPUsePenalty, libdsdp), Cint, (Ptr{Void}, Cint), dsdp, arg2)
 end
 
 function PrintLogInfo(arg1::Integer)
     ccall((:DSDPPrintLogInfo, libdsdp), Cint, (Cint,), arg1)
 end
 
-function ComputeMinimumXEigenvalue(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPComputeMinimumXEigenvalue, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function ComputeMinimumXEigenvalue(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPComputeMinimumXEigenvalue, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
 function GetTraceX(dsdp::Ptr{Void}, arg1)
     ccall((:DSDPGetTraceX, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg1)
 end
 
-function SetZBar(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetZBar, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetZBar(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetZBar, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function SetDualLowerBound(arg1::Ptr{Void}, arg2::Cdouble)
-    ccall((:DSDPSetDualLowerBound, libdsdp), Cint, (Ptr{Void}, Cdouble), arg1, arg2)
+function SetDualLowerBound(dsdp::Ptr{Void}, arg2::Cdouble)
+    ccall((:DSDPSetDualLowerBound, libdsdp), Cint, (Ptr{Void}, Cdouble), dsdp, arg2)
 end
 
-function GetDataNorms(arg1::Ptr{Void}, arg2::NTuple{3, Cdouble})
-    ccall((:DSDPGetDataNorms, libdsdp), Cint, (Ptr{Void}, NTuple{3, Cdouble}), arg1, arg2)
+function GetDataNorms(dsdp::Ptr{Void}, arg2::NTuple{3, Cdouble})
+    ccall((:DSDPGetDataNorms, libdsdp), Cint, (Ptr{Void}, NTuple{3, Cdouble}), dsdp, arg2)
 end
 
-function GetYMaxNorm(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPGetYMaxNorm, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), arg1, arg2)
+function GetYMaxNorm(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPGetYMaxNorm, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}), dsdp, arg2)
 end
 
 function SDPConeUseFullSymmetricFormat(arg1::SDPCone, arg2::Integer)
@@ -590,42 +604,42 @@ function SDPConeUsePackedFormat(arg1::SDPCone, arg2::Integer)
     ccall((:SDPConeUsePackedFormat, libdsdp), Cint, (SDPCone, Cint), arg1, arg2)
 end
 
-function SetFixedVariable(arg1::Ptr{Void}, arg2::Integer, arg3::Cdouble)
-    ccall((:DSDPSetFixedVariable, libdsdp), Cint, (Ptr{Void}, Cint, Cdouble), arg1, arg2, arg3)
+function SetFixedVariable(dsdp::Ptr{Void}, arg2::Integer, arg3::Cdouble)
+    ccall((:DSDPSetFixedVariable, libdsdp), Cint, (Ptr{Void}, Cint, Cdouble), dsdp, arg2, arg3)
 end
 
-function SetFixedVariables(arg1::Ptr{Void}, arg2, arg3, arg4, arg5::Integer)
-    ccall((:DSDPSetFixedVariables, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5)
+function SetFixedVariables(dsdp::Ptr{Void}, arg2, arg3, arg4, arg5::Integer)
+    ccall((:DSDPSetFixedVariables, libdsdp), Cint, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3, arg4, arg5)
 end
 
-function GetFixedYX(arg1::Ptr{Void}, arg2::Integer, arg3)
-    ccall((:DSDPGetFixedYX, libdsdp), Cint, (Ptr{Void}, Cint, Ptr{Cdouble}), arg1, arg2, arg3)
+function GetFixedYX(dsdp::Ptr{Void}, arg2::Integer, arg3)
+    ccall((:DSDPGetFixedYX, libdsdp), Cint, (Ptr{Void}, Cint, Ptr{Cdouble}), dsdp, arg2, arg3)
 end
 
-function View(arg1::Ptr{Void})
-    ccall((:DSDPView, libdsdp), Cint, (Ptr{Void},), arg1)
+function View(dsdp::Ptr{Void})
+    ccall((:DSDPView, libdsdp), Cint, (Ptr{Void},), dsdp)
 end
 
 function PrintOptions()
     ccall((:DSDPPrintOptions, libdsdp), Cint, ())
 end
 
-function PrintData(arg1::Ptr{Void}, arg2::SDPCone, arg3::LPCone)
-    ccall((:DSDPPrintData, libdsdp), Cint, (Ptr{Void}, SDPCone, LPCone), arg1, arg2, arg3)
+function PrintData(dsdp::Ptr{Void}, arg2::SDPCone, arg3::LPCone)
+    ccall((:DSDPPrintData, libdsdp), Cint, (Ptr{Void}, SDPCone, LPCone), dsdp, arg2, arg3)
 end
 
 #function PrintSolution(arg1, arg2::Ptr{Void}, arg3::SDPCone, arg4::LPCone)
 #    ccall((:DSDPPrintSolution, libdsdp), Cint, (Ptr{FILE}, DSDP, SDPCone, LPCone), arg1, arg2, arg3, arg4)
 #end
 
-function SetOptions(arg1::Ptr{Void}, arg2, arg3::Integer)
-    ccall((:DSDPSetOptions, libdsdp), Cint, (Ptr{Void}, Ptr{Cstring}, Cint), arg1, arg2, arg3)
+function SetOptions(dsdp::Ptr{Void}, arg2, arg3::Integer)
+    ccall((:DSDPSetOptions, libdsdp), Cint, (Ptr{Void}, Ptr{Cstring}, Cint), dsdp, arg2, arg3)
 end
 
-function ReadOptions(arg1::Ptr{Void}, arg2)
-    ccall((:DSDPReadOptions, libdsdp), Cint, (Ptr{Void}, Ptr{UInt8}), arg1, arg2)
+function ReadOptions(dsdp::Ptr{Void}, arg2)
+    ccall((:DSDPReadOptions, libdsdp), Cint, (Ptr{Void}, Ptr{UInt8}), dsdp, arg2)
 end
 
-function SetDestroyRoutine(arg1::Ptr{Void}, arg2, arg3)
-    ccall((:DSDPSetDestroyRoutine, libdsdp), Cint, (Ptr{Void}, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3)
+function SetDestroyRoutine(dsdp::Ptr{Void}, arg2, arg3)
+    ccall((:DSDPSetDestroyRoutine, libdsdp), Cint, (Ptr{Void}, Ptr{Void}, Ptr{Void}), dsdp, arg2, arg3)
 end

--- a/src/dsdp5_API.jl
+++ b/src/dsdp5_API.jl
@@ -3,621 +3,620 @@
 
 
 function SetConvergenceFlag(dsdp::DSDPT, arg2::DSDPTerminationReason)
-    ccall((:DSDPSetConvergenceFlag, libdsdp), Cint, (DSDPT, DSDPTerminationReason), dsdp, arg2)
+    @dsdp_ccall DSDPSetConvergenceFlag (DSDPT, DSDPTerminationReason) dsdp arg2
 end
 
 function Create(m::Integer)
     dsdp = Ref{DSDPT}()
-    info = ccall((:DSDPCreate, libdsdp), Cint, (Cint, Ref{DSDPT}), m, dsdp)
-    @assert iszero(info)
+    @dsdp_ccall DSDPCreate (Cint, Ref{DSDPT}) m dsdp
     dsdp[]
 end
 
 function Setup(dsdp::DSDPT)
-    ccall((:DSDPSetup, libdsdp), Cint, (DSDPT,), dsdp)
+    @dsdp_ccall DSDPSetup (DSDPT,) dsdp
 end
 
 function Solve(dsdp::DSDPT)
-    ccall((:DSDPSolve, libdsdp), Cint, (DSDPT,), dsdp)
+    @dsdp_ccall DSDPSolve (DSDPT,) dsdp
 end
 
 function ComputeX(dsdp::DSDPT)
-    ccall((:DSDPComputeX, libdsdp), Cint, (DSDPT,), dsdp)
+    @dsdp_ccall DSDPComputeX (DSDPT,) dsdp
 end
 
 function ComputeAndFactorS(dsdp::DSDPT, arg2)
-    ccall((:DSDPComputeAndFactorS, libdsdp), Cint, (DSDPT, Ptr{DSDPTruth}), dsdp, arg2)
+    @dsdp_ccall DSDPComputeAndFactorS (DSDPT, Ptr{DSDPTruth}) dsdp arg2
 end
 
 function Destroy(dsdp::DSDPT)
-    ccall((:DSDPDestroy, libdsdp), Cint, (DSDPT,), dsdp)
+    @dsdp_ccall DSDPDestroy (DSDPT,) dsdp
 end
 
-function CreateBCone(dsdp::DSDPT, arg2)
-    ccall((:DSDPCreateBCone, libdsdp), Cint, (DSDPT, Ptr{BCone}), dsdp, arg2)
+function CreateBCone(dsdp::DSDPT)
+    bcone = Ref{BCone}()
+    @dsdp_ccall DSDPCreateBCone (DSDPT, Ref{BCone}) dsdp bcone
+    bcone[]
 end
 
 function BConeAllocateBounds(arg1::BCone, arg2::Integer)
-    ccall((:BConeAllocateBounds, libdsdp), Cint, (BCone, Cint), arg1, arg2)
+    @dsdp_ccall BConeAllocateBounds (BCone, Cint) arg1 arg2
 end
 
 function BConeSetLowerBound(arg1::BCone, arg2::Integer, arg3::Cdouble)
-    ccall((:BConeSetLowerBound, libdsdp), Cint, (BCone, Cint, Cdouble), arg1, arg2, arg3)
+    @dsdp_ccall BConeSetLowerBound (BCone, Cint, Cdouble) arg1 arg2 arg3
 end
 
 function BConeSetUpperBound(arg1::BCone, arg2::Integer, arg3::Cdouble)
-    ccall((:BConeSetUpperBound, libdsdp), Cint, (BCone, Cint, Cdouble), arg1, arg2, arg3)
+    @dsdp_ccall BConeSetUpperBound (BCone, Cint, Cdouble) arg1 arg2 arg3
 end
 
 function BConeSetPSlackVariable(arg1::BCone, arg2::Integer)
-    ccall((:BConeSetPSlackVariable, libdsdp), Cint, (BCone, Cint), arg1, arg2)
+    @dsdp_ccall BConeSetPSlackVariable (BCone, Cint) arg1 arg2
 end
 
 function BConeSetPSurplusVariable(arg1::BCone, arg2::Integer)
-    ccall((:BConeSetPSurplusVariable, libdsdp), Cint, (BCone, Cint), arg1, arg2)
+    @dsdp_ccall BConeSetPSurplusVariable (BCone, Cint) arg1 arg2
 end
 
 function BConeScaleBarrier(arg1::BCone, arg2::Cdouble)
-    ccall((:BConeScaleBarrier, libdsdp), Cint, (BCone, Cdouble), arg1, arg2)
+    @dsdp_ccall BConeScaleBarrier (BCone, Cdouble) arg1 arg2
 end
 
 function BConeView(arg1::BCone)
-    ccall((:BConeView, libdsdp), Cint, (BCone,), arg1)
+    @dsdp_ccall BConeView (BCone,) arg1
 end
 
 function BConeSetXArray(arg1::BCone, arg2, arg3::Integer)
-    ccall((:BConeSetXArray, libdsdp), Cint, (BCone, Ptr{Cdouble}, Cint), arg1, arg2, arg3)
+    @dsdp_ccall BConeSetXArray (BCone, Ptr{Cdouble}, Cint) arg1 arg2 arg3
 end
 
 function BConeCopyX(arg1::BCone, arg2, arg3, arg4::Integer)
-    ccall((:BConeCopyX, libdsdp), Cint, (BCone, Ptr{Cdouble}, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4)
+    @dsdp_ccall BConeCopyX (BCone, Ptr{Cdouble}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4
 end
 
 function BoundDualVariables(dsdp::DSDPT, arg2::Cdouble, arg3::Cdouble)
-    ccall((:DSDPBoundDualVariables, libdsdp), Cint, (DSDPT, Cdouble, Cdouble), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPBoundDualVariables (DSDPT, Cdouble, Cdouble) dsdp arg2 arg3
 end
 
 function SetYBounds(dsdp::DSDPT, arg2::Cdouble, arg3::Cdouble)
-    ccall((:DSDPSetYBounds, libdsdp), Cint, (DSDPT, Cdouble, Cdouble), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPSetYBounds (DSDPT, Cdouble, Cdouble) dsdp arg2 arg3
 end
 
 function GetYBounds(dsdp::DSDPT, arg2, arg3)
-    ccall((:DSDPGetYBounds, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Ptr{Cdouble}), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPGetYBounds (DSDPT, Ptr{Cdouble}, Ptr{Cdouble}) dsdp arg2 arg3
 end
 
 function CreateLPCone(dsdp::DSDPT, arg2)
-    ccall((:DSDPCreateLPCone, libdsdp), Cint, (DSDPT, Ptr{LPCone}), dsdp, arg2)
+    @dsdp_ccall DSDPCreateLPCone (DSDPT, Ptr{LPCone}) dsdp arg2
 end
 
 function LPConeSetData(arg1::LPCone, arg2::Integer, arg3, arg4, arg5)
-    ccall((:LPConeSetData, libdsdp), Cint, (LPCone, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}), arg1, arg2, arg3, arg4, arg5)
+    @dsdp_ccall LPConeSetData (LPCone, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}) arg1 arg2 arg3 arg4 arg5
 end
 
 function LPConeSetData2(arg1::LPCone, arg2::Integer, arg3, arg4, arg5)
-    ccall((:LPConeSetData2, libdsdp), Cint, (LPCone, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}), arg1, arg2, arg3, arg4, arg5)
+    @dsdp_ccall LPConeSetData2 (LPCone, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}) arg1 arg2 arg3 arg4 arg5
 end
 
 function LPConeGetData(arg1::LPCone, arg2::Integer, arg3, arg4::Integer)
-    ccall((:LPConeGetData, libdsdp), Cint, (LPCone, Cint, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4)
+    @dsdp_ccall LPConeGetData (LPCone, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4
 end
 
 function LPConeScaleBarrier(arg1::LPCone, arg2::Cdouble)
-    ccall((:LPConeScaleBarrier, libdsdp), Cint, (LPCone, Cdouble), arg1, arg2)
+    @dsdp_ccall LPConeScaleBarrier (LPCone, Cdouble) arg1 arg2
 end
 
 function LPConeGetXArray(arg1::LPCone, arg2, arg3)
-    ccall((:LPConeGetXArray, libdsdp), Cint, (LPCone, Ptr{Ptr{Cdouble}}, Ptr{Cint}), arg1, arg2, arg3)
+    @dsdp_ccall LPConeGetXArray (LPCone, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3
 end
 
 function LPConeGetSArray(arg1::LPCone, arg2, arg3)
-    ccall((:LPConeGetSArray, libdsdp), Cint, (LPCone, Ptr{Ptr{Cdouble}}, Ptr{Cint}), arg1, arg2, arg3)
+    @dsdp_ccall LPConeGetSArray (LPCone, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3
 end
 
 function LPConeGetDimension(arg1::LPCone, arg2)
-    ccall((:LPConeGetDimension, libdsdp), Cint, (LPCone, Ptr{Cint}), arg1, arg2)
+    @dsdp_ccall LPConeGetDimension (LPCone, Ptr{Cint}) arg1 arg2
 end
 
 function LPConeView(lpcone::LPCone)
-    ccall((:LPConeView, libdsdp), Cint, (LPCone,), lpcone)
+    @dsdp_ccall LPConeView (LPCone,) lpcone
 end
 
 function LPConeView2(lpcone::LPCone)
-    ccall((:LPConeView2, libdsdp), Cint, (LPCone,), lpcone)
+    @dsdp_ccall LPConeView2 (LPCone,) lpcone
 end
 
 function LPConeCopyS(arg1::LPCone, arg2, arg3::Integer)
-    ccall((:LPConeCopyS, libdsdp), Cint, (LPCone, Ptr{Cdouble}, Cint), arg1, arg2, arg3)
+    @dsdp_ccall LPConeCopyS (LPCone, Ptr{Cdouble}, Cint) arg1 arg2 arg3
 end
 
 function CreateSDPCone(dsdp::DSDPT, n::Integer)
     sdpcone = Ref{SDPCone}()
-    info = ccall((:DSDPCreateSDPCone, libdsdp), Cint, (DSDPT, Cint, Ref{SDPCone}), dsdp, n, sdpcone)
-    @assert iszero(info)
+    @dsdp_ccall DSDPCreateSDPCone (DSDPT, Cint, Ref{SDPCone}) dsdp n sdpcone
     sdpcone[]
 end
 function CreateSDPCone(dsdp::DSDPT, arg2::Integer, arg3)
-    ccall((:DSDPCreateSDPCone, libdsdp), Cint, (DSDPT, Cint, Ptr{SDPCone}), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPCreateSDPCone (DSDPT, Cint, Ptr{SDPCone}) dsdp arg2 arg3
 end
 
 function SDPConeSetBlockSize(sdpcone::SDPCone, i::Integer, j::Integer)
-    info = ccall((:SDPConeSetBlockSize, libdsdp), Cint, (SDPCone, Cint, Cint), sdpcone, i, j)
-    @assert iszero(info)
+    @dsdp_ccall SDPConeSetBlockSize (SDPCone, Cint, Cint) sdpcone i j
 end
 
 function SDPConeGetBlockSize(arg1::SDPCone, arg2::Integer, arg3)
-    ccall((:SDPConeGetBlockSize, libdsdp), Cint, (SDPCone, Cint, Ptr{Cint}), arg1, arg2, arg3)
+    @dsdp_ccall SDPConeGetBlockSize (SDPCone, Cint, Ptr{Cint}) arg1 arg2 arg3
 end
 
 function SDPConeSetStorageFormat(arg1::SDPCone, arg2::Integer, arg3::UInt8)
-    ccall((:SDPConeSetStorageFormat, libdsdp), Cint, (SDPCone, Cint, UInt8), arg1, arg2, arg3)
+    @dsdp_ccall SDPConeSetStorageFormat (SDPCone, Cint, UInt8) arg1 arg2 arg3
 end
 
 function SDPConeGetStorageFormat(arg1::SDPCone, arg2::Integer, arg3)
-    ccall((:SDPConeGetStorageFormat, libdsdp), Cint, (SDPCone, Cint, Cstring), arg1, arg2, arg3)
+    @dsdp_ccall SDPConeGetStorageFormat (SDPCone, Cint, Cstring) arg1 arg2 arg3
 end
 
 function SDPConeCheckStorageFormat(arg1::SDPCone, arg2::Integer, arg3::UInt8)
-    ccall((:SDPConeCheckStorageFormat, libdsdp), Cint, (SDPCone, Cint, UInt8), arg1, arg2, arg3)
+    @dsdp_ccall SDPConeCheckStorageFormat (SDPCone, Cint, UInt8) arg1 arg2 arg3
 end
 
 function SDPConeSetSparsity(arg1::SDPCone, arg2::Integer, arg3::Integer)
-    ccall((:SDPConeSetSparsity, libdsdp), Cint, (SDPCone, Cint, Cint), arg1, arg2, arg3)
+    @dsdp_ccall SDPConeSetSparsity (SDPCone, Cint, Cint) arg1 arg2 arg3
 end
 
 function SDPConeView(arg1::SDPCone)
-    ccall((:SDPConeView, libdsdp), Cint, (SDPCone,), arg1)
+    @dsdp_ccall SDPConeView (SDPCone,) arg1
 end
 
 function SDPConeView2(arg1::SDPCone)
-    ccall((:SDPConeView2, libdsdp), Cint, (SDPCone,), arg1)
+    @dsdp_ccall SDPConeView2 (SDPCone,) arg1
 end
 
 function SDPConeView3(arg1::SDPCone)
-    ccall((:SDPConeView3, libdsdp), Cint, (SDPCone,), arg1)
+    @dsdp_ccall SDPConeView3 (SDPCone,) arg1
 end
 
 function SDPConeSetASparseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
-    ccall((:SDPConeSetASparseVecMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    @dsdp_ccall SDPConeSetASparseVecMat (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
 end
 
 function SDPConeSetADenseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6, arg7::Integer)
-    ccall((:SDPConeSetADenseVecMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cdouble, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    @dsdp_ccall SDPConeSetADenseVecMat (SDPCone, Cint, Cint, Cint, Cdouble, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7
 end
 
 function SDPConeSetARankOneMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
-    ccall((:SDPConeSetARankOneMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    @dsdp_ccall SDPConeSetARankOneMat (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
 end
 
 function SDPConeSetConstantMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
-    ccall((:SDPConeSetConstantMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cdouble), arg1, arg2, arg3, arg4, arg5)
+    @dsdp_ccall SDPConeSetConstantMat (SDPCone, Cint, Cint, Cint, Cdouble) arg1 arg2 arg3 arg4 arg5
 end
 
 function SDPConeSetZeroMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer)
-    ccall((:SDPConeSetZeroMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint), arg1, arg2, arg3, arg4)
+    @dsdp_ccall SDPConeSetZeroMat (SDPCone, Cint, Cint, Cint) arg1 arg2 arg3 arg4
 end
 
 function SDPConeSetIdentity(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
-    ccall((:SDPConeSetIdentity, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cdouble), arg1, arg2, arg3, arg4, arg5)
+    @dsdp_ccall SDPConeSetIdentity (SDPCone, Cint, Cint, Cint, Cdouble) arg1 arg2 arg3 arg4 arg5
 end
 
 function SDPConeViewDataMatrix(arg1::SDPCone, arg2::Integer, arg3::Integer)
-    ccall((:SDPConeViewDataMatrix, libdsdp), Cint, (SDPCone, Cint, Cint), arg1, arg2, arg3)
+    @dsdp_ccall SDPConeViewDataMatrix (SDPCone, Cint, Cint) arg1 arg2 arg3
 end
 
 function SDPConeMatrixView(arg1::SDPCone, arg2::Integer)
-    ccall((:SDPConeMatrixView, libdsdp), Cint, (SDPCone, Cint), arg1, arg2)
+    @dsdp_ccall SDPConeMatrixView (SDPCone, Cint) arg1 arg2
 end
 
 function SDPConeAddASparseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
-    ccall((:SDPConeAddASparseVecMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    @dsdp_ccall SDPConeAddASparseVecMat (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
 end
 
 function SDPConeAddADenseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6, arg7::Integer)
-    ccall((:SDPConeAddADenseVecMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cdouble, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    @dsdp_ccall SDPConeAddADenseVecMat (SDPCone, Cint, Cint, Cint, Cdouble, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7
 end
 
 function SDPConeAddConstantMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
-    ccall((:SDPConeAddConstantMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cdouble), arg1, arg2, arg3, arg4, arg5)
+    @dsdp_ccall SDPConeAddConstantMat (SDPCone, Cint, Cint, Cint, Cdouble) arg1 arg2 arg3 arg4 arg5
 end
 
 function SDPConeAddIdentity(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
-    ccall((:SDPConeAddIdentity, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cdouble), arg1, arg2, arg3, arg4, arg5)
+    @dsdp_ccall SDPConeAddIdentity (SDPCone, Cint, Cint, Cint, Cdouble) arg1 arg2 arg3 arg4 arg5
 end
 
 function SDPConeAddARankOneMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
-    ccall((:SDPConeAddARankOneMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    @dsdp_ccall SDPConeAddARankOneMat (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
 end
 
 function SDPConeAddSparseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Integer, arg6, arg7, arg8::Integer)
-    ccall((:SDPConeAddSparseVecMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    @dsdp_ccall SDPConeAddSparseVecMat (SDPCone, Cint, Cint, Cint, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8
 end
 
 function SDPConeAddDenseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5, arg6::Integer)
-    ccall((:SDPConeAddDenseVecMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6)
+    @dsdp_ccall SDPConeAddDenseVecMat (SDPCone, Cint, Cint, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6
 end
 
 function SDPConeSetSparseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Integer, arg6, arg7, arg8::Integer)
-    ccall((:SDPConeSetSparseVecMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    @dsdp_ccall SDPConeSetSparseVecMat (SDPCone, Cint, Cint, Cint, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8
 end
 
 function SDPConeSetDenseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5, arg6::Integer)
-    ccall((:SDPConeSetDenseVecMat, libdsdp), Cint, (SDPCone, Cint, Cint, Cint, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6)
+    @dsdp_ccall SDPConeSetDenseVecMat (SDPCone, Cint, Cint, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6
 end
 
 function SDPConeSetXMat(arg1::SDPCone, arg2::Integer, arg3::Integer)
-    ccall((:SDPConeSetXMat, libdsdp), Cint, (SDPCone, Cint, Cint), arg1, arg2, arg3)
+    @dsdp_ccall SDPConeSetXMat (SDPCone, Cint, Cint) arg1 arg2 arg3
 end
 
 function SDPConeSetXArray(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4, arg5::Integer)
-    ccall((:SDPConeSetXArray, libdsdp), Cint, (SDPCone, Cint, Cint, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5)
+    @dsdp_ccall SDPConeSetXArray (SDPCone, Cint, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5
 end
 
 function SDPConeGetXArray(arg1::SDPCone, arg2::Integer, arg3, arg4)
-    ccall((:SDPConeGetXArray, libdsdp), Cint, (SDPCone, Cint, Ptr{Ptr{Cdouble}}, Ptr{Cint}), arg1, arg2, arg3, arg4)
+    @dsdp_ccall SDPConeGetXArray (SDPCone, Cint, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3 arg4
 end
 
 function SDPConeRestoreXArray(arg1::SDPCone, arg2::Integer, arg3, arg4)
-    ccall((:SDPConeRestoreXArray, libdsdp), Cint, (SDPCone, Cint, Ptr{Ptr{Cdouble}}, Ptr{Cint}), arg1, arg2, arg3, arg4)
+    @dsdp_ccall SDPConeRestoreXArray (SDPCone, Cint, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3 arg4
 end
 
 function SDPConeCheckData(arg1::SDPCone)
-    ccall((:SDPConeCheckData, libdsdp), Cint, (SDPCone,), arg1)
+    @dsdp_ccall SDPConeCheckData (SDPCone,) arg1
 end
 
 function SDPConeRemoveDataMatrix(arg1::SDPCone, arg2::Integer, arg3::Integer)
-    ccall((:SDPConeRemoveDataMatrix, libdsdp), Cint, (SDPCone, Cint, Cint), arg1, arg2, arg3)
+    @dsdp_ccall SDPConeRemoveDataMatrix (SDPCone, Cint, Cint) arg1 arg2 arg3
 end
 
 function SDPConeGetNumberOfBlocks(arg1::SDPCone, arg2)
-    ccall((:SDPConeGetNumberOfBlocks, libdsdp), Cint, (SDPCone, Ptr{Cint}), arg1, arg2)
+    @dsdp_ccall SDPConeGetNumberOfBlocks (SDPCone, Ptr{Cint}) arg1 arg2
 end
 
 function SDPConeComputeS(arg1::SDPCone, arg2::Integer, arg3::Cdouble, arg4, arg5::Integer, arg6::Cdouble, arg7::Integer, arg8, arg9::Integer)
-    ccall((:SDPConeComputeS, libdsdp), Cint, (SDPCone, Cint, Cdouble, Ptr{Cdouble}, Cint, Cdouble, Cint, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    @dsdp_ccall SDPConeComputeS (SDPCone, Cint, Cdouble, Ptr{Cdouble}, Cint, Cdouble, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
 end
 
 function SDPConeComputeX(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4, arg5::Integer)
-    ccall((:SDPConeComputeX, libdsdp), Cint, (SDPCone, Cint, Cint, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5)
+    @dsdp_ccall SDPConeComputeX (SDPCone, Cint, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5
 end
 
 function SDPConeAddADotX(arg1::SDPCone, arg2::Integer, arg3::Cdouble, arg4, arg5::Integer, arg6, arg7::Integer)
-    ccall((:SDPConeAddADotX, libdsdp), Cint, (SDPCone, Cint, Cdouble, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    @dsdp_ccall SDPConeAddADotX (SDPCone, Cint, Cdouble, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7
 end
 
 function SDPConeViewX(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4, arg5::Integer)
-    ccall((:SDPConeViewX, libdsdp), Cint, (SDPCone, Cint, Cint, Ptr{Cdouble}, Cint), arg1, arg2, arg3, arg4, arg5)
+    @dsdp_ccall SDPConeViewX (SDPCone, Cint, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5
 end
 
 function SDPConeSetLanczosIterations(arg1::SDPCone, arg2::Integer)
-    ccall((:SDPConeSetLanczosIterations, libdsdp), Cint, (SDPCone, Cint), arg1, arg2)
+    @dsdp_ccall SDPConeSetLanczosIterations (SDPCone, Cint) arg1 arg2
 end
 
 function SDPConeScaleBarrier(arg1::SDPCone, arg2::Integer, arg3::Cdouble)
-    ccall((:SDPConeScaleBarrier, libdsdp), Cint, (SDPCone, Cint, Cdouble), arg1, arg2, arg3)
+    @dsdp_ccall SDPConeScaleBarrier (SDPCone, Cint, Cdouble) arg1 arg2 arg3
 end
 
 function SDPConeXVMultiply(sdpcone::SDPCone, arg2::Integer, arg3::Vector, arg4::Vector)
     n = length(arg3)
     @assert n == length(arg4)
-    ccall((:SDPConeXVMultiply, libdsdp), Cint, (SDPCone, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), sdpcone, arg2, pointer(arg3), pointer(arg4), n)
+    @dsdp_ccall SDPConeXVMultiply (SDPCone, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint) sdpcone arg2 pointer(arg3) pointer(arg4) n
 end
 
 function SDPConeComputeXV(sdpcone::SDPCone, arg2::Integer)
     derror = Ref{Cint}()
-    ccall((:SDPConeComputeXV, libdsdp), Cint, (SDPCone, Cint, Ref{Cint}), sdpcone, arg2, derror)
+    @dsdp_ccall SDPConeComputeXV (SDPCone, Cint, Ref{Cint}) sdpcone arg2 derror
     derror[]
 end
 
 function SDPConeAddXVAV(arg1::SDPCone, arg2::Integer, arg3::Vector, arg5::Vector)
-    ccall((:SDPConeAddXVAV, libdsdp), Cint, (SDPCone, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), arg1, arg2, pointer(arg3), length(arg3), pointer(arg5), length(arg5))
+    @dsdp_ccall SDPConeAddXVAV (SDPCone, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint) arg1 arg2 pointer(arg3) length(arg3) pointer(arg5) length(arg5)
 end
 
 function SDPConeUseLAPACKForDualMatrix(arg1::SDPCone, arg2::Integer)
-    ccall((:SDPConeUseLAPACKForDualMatrix, libdsdp), Cint, (SDPCone, Cint), arg1, arg2)
+    @dsdp_ccall SDPConeUseLAPACKForDualMatrix (SDPCone, Cint) arg1 arg2
 end
 
 function SetDualObjective(dsdp::DSDPT, arg2::Integer, arg3::Cdouble)
-    ccall((:DSDPSetDualObjective, libdsdp), Cint, (DSDPT, Cint, Cdouble), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPSetDualObjective (DSDPT, Cint, Cdouble) dsdp arg2 arg3
 end
 
 function AddObjectiveConstant(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPAddObjectiveConstant, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPAddObjectiveConstant (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetDObjective(dsdp::DSDPT)
     dobj = Ref{Cdouble}()
-    ccall((:DSDPGetDObjective, libdsdp), Cint, (DSDPT, Ref{Cdouble}), dsdp, dobj)
+    @dsdp_ccall DSDPGetDObjective (DSDPT, Ref{Cdouble}) dsdp dobj
     dobj[]
 end
 
 function GetDDObjective(dsdp::DSDPT)
     ddobj = Ref{Cdouble}()
-    ccall((:DSDPGetDDObjective, libdsdp), Cint, (DSDPT, Ref{Cdouble}), dsdp, ddobj)
+    @dsdp_ccall DSDPGetDDObjective (DSDPT, Ref{Cdouble}) dsdp ddobj
     ddobj[]
 end
 
 function GetPObjective(dsdp::DSDPT)
     pobj = Ref{Cdouble}()
-    ccall((:DSDPGetPObjective, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, pobj)
+    @dsdp_ccall DSDPGetPObjective (DSDPT, Ptr{Cdouble}) dsdp pobj
     pobj[]
 end
 
 function GetPPObjective(dsdp::DSDPT)
     ppobj = Ref{Cdouble}()
-    ccall((:DSDPGetPPObjective, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, ppobj)
+    @dsdp_ccall DSDPGetPPObjective (DSDPT, Ptr{Cdouble}) dsdp ppobj
     ppobj[]
 end
 
 function GetDualityGap(dsdp::DSDPT)
     dgap = Ref{Cdouble}()
-    ccall((:DSDPGetDualityGap, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, dgap)
+    @dsdp_ccall DSDPGetDualityGap (DSDPT, Ptr{Cdouble}) dsdp dgap
     dgap[]
 end
 
 function GetScale(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetScale, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetScale (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function SetScale(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetScale, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetScale (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetPenaltyParameter(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetPenaltyParameter, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetPenaltyParameter (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function GetPenalty(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetPenalty, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetPenalty (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function CopyB(dsdp::DSDPT, arg2, arg3::Integer)
-    ccall((:DSDPCopyB, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPCopyB (DSDPT, Ptr{Cdouble}, Cint) dsdp arg2 arg3
 end
 
 function SetR0(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetR0, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetR0 (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetR(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetR, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetR (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function SetRTolerance(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetRTolerance, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetRTolerance (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetRTolerance(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetRTolerance, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetRTolerance (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function SetY0(dsdp::DSDPT, arg2::Integer, arg3::Cdouble)
-    ccall((:DSDPSetY0, libdsdp), Cint, (DSDPT, Cint, Cdouble), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPSetY0 (DSDPT, Cint, Cdouble) dsdp arg2 arg3
 end
 
 function GetY(dsdp::DSDPT, arg2, arg3::Integer)
-    ccall((:DSDPGetY, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPGetY (DSDPT, Ptr{Cdouble}, Cint) dsdp arg2 arg3
 end
 
 function GetYMakeX(dsdp::DSDPT, arg2, arg3::Integer)
-    ccall((:DSDPGetYMakeX, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPGetYMakeX (DSDPT, Ptr{Cdouble}, Cint) dsdp arg2 arg3
 end
 
 function GetDYMakeX(dsdp::DSDPT, arg2, arg3::Integer)
-    ccall((:DSDPGetDYMakeX, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPGetDYMakeX (DSDPT, Ptr{Cdouble}, Cint) dsdp arg2 arg3
 end
 
 function GetMuMakeX(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetMuMakeX, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetMuMakeX (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function GetBarrierParameter(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetBarrierParameter, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetBarrierParameter (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function SetBarrierParameter(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetBarrierParameter, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetBarrierParameter (DSDPT, Cdouble) dsdp arg2
 end
 
 function ReuseMatrix(dsdp::DSDPT, arg2::Integer)
-    ccall((:DSDPReuseMatrix, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
+    @dsdp_ccall DSDPReuseMatrix (DSDPT, Cint) dsdp arg2
 end
 
 function GetReuseMatrix(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetReuseMatrix, libdsdp), Cint, (DSDPT, Ptr{Cint}), dsdp, arg2)
+    @dsdp_ccall DSDPGetReuseMatrix (DSDPT, Ptr{Cint}) dsdp arg2
 end
 
 function GetDimension(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetDimension, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetDimension (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function SetMaxIts(dsdp::DSDPT, arg2::Integer)
-    ccall((:DSDPSetMaxIts, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
+    @dsdp_ccall DSDPSetMaxIts (DSDPT, Cint) dsdp arg2
 end
 
 function GetMaxIts(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetMaxIts, libdsdp), Cint, (DSDPT, Ptr{Cint}), dsdp, arg2)
+    @dsdp_ccall DSDPGetMaxIts (DSDPT, Ptr{Cint}) dsdp arg2
 end
 
 function SetStepTolerance(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetStepTolerance, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetStepTolerance (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetStepTolerance(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetStepTolerance, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetStepTolerance (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function SetGapTolerance(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetGapTolerance, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetGapTolerance (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetGapTolerance(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetGapTolerance, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetGapTolerance (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function SetPNormTolerance(dsdp::DSDPT, arg2::Real)
-    ccall((:DSDPSetPNormTolerance, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetPNormTolerance (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetPNormTolerance(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetPNormTolerance, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetPNormTolerance (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function SetDualBound(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetDualBound, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetDualBound (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetDualBound(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetDualBound, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetDualBound (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function SetPTolerance(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetPTolerance, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetPTolerance (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetPTolerance(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetPTolerance, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetPTolerance (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function GetPInfeasibility(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetPInfeasibility, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetPInfeasibility (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function SetMaxTrustRadius(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetMaxTrustRadius, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetMaxTrustRadius (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetMaxTrustRadius(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetMaxTrustRadius, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetMaxTrustRadius (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function StopReason(dsdp::DSDPT)
     stop = Ref{DSDPTerminationReason}()
-    ccall((:DSDPStopReason, libdsdp), Cint, (DSDPT, Ref{DSDPTerminationReason}), dsdp, stop)
+    @dsdp_ccall DSDPStopReason (DSDPT, Ref{DSDPTerminationReason}) dsdp stop
     stop[]
 end
 
 function GetSolutionType(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetSolutionType, libdsdp), Cint, (DSDPT, Ptr{DSDPSolutionType}), dsdp, arg2)
+    @dsdp_ccall DSDPGetSolutionType (DSDPT, Ptr{DSDPSolutionType}) dsdp arg2
 end
 
 function SetPotentialParameter(dsdp::DSDPT, arg2::Real)
-    ccall((:DSDPSetPotentialParameter, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetPotentialParameter (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetPotentialParameter(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetPotentialParameter, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetPotentialParameter (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function UseDynamicRho(dsdp::DSDPT, arg2::Integer)
-    ccall((:DSDPUseDynamicRho, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
+    @dsdp_ccall DSDPUseDynamicRho (DSDPT, Cint) dsdp arg2
 end
 
 function GetPotential(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetPotential, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetPotential (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function UseLAPACKForSchur(dsdp::DSDPT, arg2::Integer)
-    ccall((:DSDPUseLAPACKForSchur, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
+    @dsdp_ccall DSDPUseLAPACKForSchur (DSDPT, Cint) dsdp arg2
 end
 
 function GetNumberOfVariables(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetNumberOfVariables, libdsdp), Cint, (DSDPT, Ptr{Cint}), dsdp, arg2)
+    @dsdp_ccall DSDPGetNumberOfVariables (DSDPT, Ptr{Cint}) dsdp arg2
 end
 
 function GetFinalErrors(dsdp::DSDPT, arg2::NTuple{6, Cdouble})
-    ccall((:DSDPGetFinalErrors, libdsdp), Cint, (DSDPT, NTuple{6, Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetFinalErrors (DSDPT, NTuple{6, Cdouble}) dsdp arg2
 end
 
 function GetGapHistory(dsdp::DSDPT, arg2, arg3::Integer)
-    ccall((:DSDPGetGapHistory, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPGetGapHistory (DSDPT, Ptr{Cdouble}, Cint) dsdp arg2 arg3
 end
 
 function GetRHistory(dsdp::DSDPT, arg2, arg3::Integer)
-    ccall((:DSDPGetRHistory, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Cint), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPGetRHistory (DSDPT, Ptr{Cdouble}, Cint) dsdp arg2 arg3
 end
 
 function GetIts(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetIts, libdsdp), Cint, (DSDPT, Ptr{Cint}), dsdp, arg2)
+    @dsdp_ccall DSDPGetIts (DSDPT, Ptr{Cint}) dsdp arg2
 end
 
 function GetPnorm(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetPnorm, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetPnorm (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function GetStepLengths(dsdp::DSDPT, arg2, arg3)
-    ccall((:DSDPGetStepLengths, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Ptr{Cdouble}), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPGetStepLengths (DSDPT, Ptr{Cdouble}, Ptr{Cdouble}) dsdp arg2 arg3
 end
 
 function SetMonitor(dsdp::DSDPT, arg2, arg3)
-    ccall((:DSDPSetMonitor, libdsdp), Cint, (DSDPT, DSDPT, DSDPT), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPSetMonitor (DSDPT, DSDPT, DSDPT) dsdp arg2 arg3
 end
 
 function SetStandardMonitor(dsdp::DSDPT, arg2::Integer)
-    ccall((:DSDPSetStandardMonitor, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
+    @dsdp_ccall DSDPSetStandardMonitor (DSDPT, Cint) dsdp arg2
 end
 
 function SetFileMonitor(dsdp::DSDPT, arg2::Integer)
-    ccall((:DSDPSetFileMonitor, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
+    @dsdp_ccall DSDPSetFileMonitor (DSDPT, Cint) dsdp arg2
 end
 
 function SetPenaltyParameter(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetPenaltyParameter, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetPenaltyParameter (DSDPT, Cdouble) dsdp arg2
 end
 
 function UsePenalty(dsdp::DSDPT, arg2::Integer)
-    ccall((:DSDPUsePenalty, libdsdp), Cint, (DSDPT, Cint), dsdp, arg2)
+    @dsdp_ccall DSDPUsePenalty (DSDPT, Cint) dsdp arg2
 end
 
 function PrintLogInfo(arg1::Integer)
-    ccall((:DSDPPrintLogInfo, libdsdp), Cint, (Cint,), arg1)
+    @dsdp_ccall DSDPPrintLogInfo (Cint,) arg1
 end
 
 function ComputeMinimumXEigenvalue(dsdp::DSDPT, arg2)
-    ccall((:DSDPComputeMinimumXEigenvalue, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPComputeMinimumXEigenvalue (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function GetTraceX(dsdp::DSDPT, arg1)
-    ccall((:DSDPGetTraceX, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg1)
+    @dsdp_ccall DSDPGetTraceX (DSDPT, Ptr{Cdouble}) dsdp arg1
 end
 
 function SetZBar(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetZBar, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetZBar (DSDPT, Cdouble) dsdp arg2
 end
 
 function SetDualLowerBound(dsdp::DSDPT, arg2::Cdouble)
-    ccall((:DSDPSetDualLowerBound, libdsdp), Cint, (DSDPT, Cdouble), dsdp, arg2)
+    @dsdp_ccall DSDPSetDualLowerBound (DSDPT, Cdouble) dsdp arg2
 end
 
 function GetDataNorms(dsdp::DSDPT, arg2::NTuple{3, Cdouble})
-    ccall((:DSDPGetDataNorms, libdsdp), Cint, (DSDPT, NTuple{3, Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetDataNorms (DSDPT, NTuple{3, Cdouble}) dsdp arg2
 end
 
 function GetYMaxNorm(dsdp::DSDPT, arg2)
-    ccall((:DSDPGetYMaxNorm, libdsdp), Cint, (DSDPT, Ptr{Cdouble}), dsdp, arg2)
+    @dsdp_ccall DSDPGetYMaxNorm (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
 function SDPConeUseFullSymmetricFormat(arg1::SDPCone, arg2::Integer)
-    ccall((:SDPConeUseFullSymmetricFormat, libdsdp), Cint, (SDPCone, Cint), arg1, arg2)
+    @dsdp_ccall SDPConeUseFullSymmetricFormat (SDPCone, Cint) arg1 arg2
 end
 
 function SDPConeUsePackedFormat(arg1::SDPCone, arg2::Integer)
-    ccall((:SDPConeUsePackedFormat, libdsdp), Cint, (SDPCone, Cint), arg1, arg2)
+    @dsdp_ccall SDPConeUsePackedFormat (SDPCone, Cint) arg1 arg2
 end
 
 function SetFixedVariable(dsdp::DSDPT, arg2::Integer, arg3::Cdouble)
-    ccall((:DSDPSetFixedVariable, libdsdp), Cint, (DSDPT, Cint, Cdouble), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPSetFixedVariable (DSDPT, Cint, Cdouble) dsdp arg2 arg3
 end
 
 function SetFixedVariables(dsdp::DSDPT, arg2, arg3, arg4, arg5::Integer)
-    ccall((:DSDPSetFixedVariables, libdsdp), Cint, (DSDPT, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cint), dsdp, arg2, arg3, arg4, arg5)
+    @dsdp_ccall DSDPSetFixedVariables (DSDPT, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cint) dsdp arg2 arg3 arg4 arg5
 end
 
 function GetFixedYX(dsdp::DSDPT, arg2::Integer, arg3)
-    ccall((:DSDPGetFixedYX, libdsdp), Cint, (DSDPT, Cint, Ptr{Cdouble}), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPGetFixedYX (DSDPT, Cint, Ptr{Cdouble}) dsdp arg2 arg3
 end
 
 function View(dsdp::DSDPT)
-    ccall((:DSDPView, libdsdp), Cint, (DSDPT,), dsdp)
+    @dsdp_ccall DSDPView (DSDPT,) dsdp
 end
 
 function PrintOptions()
@@ -625,21 +624,21 @@ function PrintOptions()
 end
 
 function PrintData(dsdp::DSDPT, arg2::SDPCone, arg3::LPCone)
-    ccall((:DSDPPrintData, libdsdp), Cint, (DSDPT, SDPCone, LPCone), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPPrintData (DSDPT, SDPCone, LPCone) dsdp arg2 arg3
 end
 
 #function PrintSolution(arg1, arg2::DSDPT, arg3::SDPCone, arg4::LPCone)
-#    ccall((:DSDPPrintSolution, libdsdp), Cint, (Ptr{FILE}, DSDP, SDPCone, LPCone), arg1, arg2, arg3, arg4)
+#    @dsdp_ccall DSDPPrintSolution (Ptr{FILE}, DSDP, SDPCone, LPCone) arg1 arg2 arg3 arg4
 #end
 
 function SetOptions(dsdp::DSDPT, arg2, arg3::Integer)
-    ccall((:DSDPSetOptions, libdsdp), Cint, (DSDPT, Ptr{Cstring}, Cint), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPSetOptions (DSDPT, Ptr{Cstring}, Cint) dsdp arg2 arg3
 end
 
 function ReadOptions(dsdp::DSDPT, arg2)
-    ccall((:DSDPReadOptions, libdsdp), Cint, (DSDPT, Ptr{UInt8}), dsdp, arg2)
+    @dsdp_ccall DSDPReadOptions (DSDPT, Ptr{UInt8}) dsdp arg2
 end
 
 function SetDestroyRoutine(dsdp::DSDPT, arg2, arg3)
-    ccall((:DSDPSetDestroyRoutine, libdsdp), Cint, (DSDPT, DSDPT, DSDPT), dsdp, arg2, arg3)
+    @dsdp_ccall DSDPSetDestroyRoutine (DSDPT, DSDPT, DSDPT) dsdp arg2 arg3
 end

--- a/src/dsdp5_API.jl
+++ b/src/dsdp5_API.jl
@@ -32,289 +32,6 @@ function Destroy(dsdp::DSDPT)
     @dsdp_ccall DSDPDestroy (DSDPT,) dsdp
 end
 
-function CreateBCone(dsdp::DSDPT)
-    bcone = Ref{BCone}()
-    @dsdp_ccall DSDPCreateBCone (DSDPT, Ref{BCone}) dsdp bcone
-    bcone[]
-end
-
-function BConeAllocateBounds(arg1::BCone, arg2::Integer)
-    @dsdp_ccall BConeAllocateBounds (BCone, Cint) arg1 arg2
-end
-
-function BConeSetLowerBound(arg1::BCone, arg2::Integer, arg3::Cdouble)
-    @dsdp_ccall BConeSetLowerBound (BCone, Cint, Cdouble) arg1 arg2 arg3
-end
-
-function BConeSetUpperBound(arg1::BCone, arg2::Integer, arg3::Cdouble)
-    @dsdp_ccall BConeSetUpperBound (BCone, Cint, Cdouble) arg1 arg2 arg3
-end
-
-function BConeSetPSlackVariable(arg1::BCone, arg2::Integer)
-    @dsdp_ccall BConeSetPSlackVariable (BCone, Cint) arg1 arg2
-end
-
-function BConeSetPSurplusVariable(arg1::BCone, arg2::Integer)
-    @dsdp_ccall BConeSetPSurplusVariable (BCone, Cint) arg1 arg2
-end
-
-function BConeScaleBarrier(arg1::BCone, arg2::Cdouble)
-    @dsdp_ccall BConeScaleBarrier (BCone, Cdouble) arg1 arg2
-end
-
-function BConeView(arg1::BCone)
-    @dsdp_ccall BConeView (BCone,) arg1
-end
-
-function BConeSetXArray(arg1::BCone, arg2, arg3::Integer)
-    @dsdp_ccall BConeSetXArray (BCone, Ptr{Cdouble}, Cint) arg1 arg2 arg3
-end
-
-function BConeCopyX(arg1::BCone, arg2, arg3, arg4::Integer)
-    @dsdp_ccall BConeCopyX (BCone, Ptr{Cdouble}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4
-end
-
-function BoundDualVariables(dsdp::DSDPT, arg2::Cdouble, arg3::Cdouble)
-    @dsdp_ccall DSDPBoundDualVariables (DSDPT, Cdouble, Cdouble) dsdp arg2 arg3
-end
-
-function SetYBounds(dsdp::DSDPT, arg2::Cdouble, arg3::Cdouble)
-    @dsdp_ccall DSDPSetYBounds (DSDPT, Cdouble, Cdouble) dsdp arg2 arg3
-end
-
-function GetYBounds(dsdp::DSDPT, arg2, arg3)
-    @dsdp_ccall DSDPGetYBounds (DSDPT, Ptr{Cdouble}, Ptr{Cdouble}) dsdp arg2 arg3
-end
-
-function CreateLPCone(dsdp::DSDPT, arg2)
-    @dsdp_ccall DSDPCreateLPCone (DSDPT, Ptr{LPCone}) dsdp arg2
-end
-
-function LPConeSetData(arg1::LPCone, arg2::Integer, arg3, arg4, arg5)
-    @dsdp_ccall LPConeSetData (LPCone, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}) arg1 arg2 arg3 arg4 arg5
-end
-
-function LPConeSetData2(arg1::LPCone, arg2::Integer, arg3, arg4, arg5)
-    @dsdp_ccall LPConeSetData2 (LPCone, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}) arg1 arg2 arg3 arg4 arg5
-end
-
-function LPConeGetData(arg1::LPCone, arg2::Integer, arg3, arg4::Integer)
-    @dsdp_ccall LPConeGetData (LPCone, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4
-end
-
-function LPConeScaleBarrier(arg1::LPCone, arg2::Cdouble)
-    @dsdp_ccall LPConeScaleBarrier (LPCone, Cdouble) arg1 arg2
-end
-
-function LPConeGetXArray(arg1::LPCone, arg2, arg3)
-    @dsdp_ccall LPConeGetXArray (LPCone, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3
-end
-
-function LPConeGetSArray(arg1::LPCone, arg2, arg3)
-    @dsdp_ccall LPConeGetSArray (LPCone, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3
-end
-
-function LPConeGetDimension(arg1::LPCone, arg2)
-    @dsdp_ccall LPConeGetDimension (LPCone, Ptr{Cint}) arg1 arg2
-end
-
-function LPConeView(lpcone::LPCone)
-    @dsdp_ccall LPConeView (LPCone,) lpcone
-end
-
-function LPConeView2(lpcone::LPCone)
-    @dsdp_ccall LPConeView2 (LPCone,) lpcone
-end
-
-function LPConeCopyS(arg1::LPCone, arg2, arg3::Integer)
-    @dsdp_ccall LPConeCopyS (LPCone, Ptr{Cdouble}, Cint) arg1 arg2 arg3
-end
-
-function CreateSDPCone(dsdp::DSDPT, n::Integer)
-    sdpcone = Ref{SDPCone}()
-    @dsdp_ccall DSDPCreateSDPCone (DSDPT, Cint, Ref{SDPCone}) dsdp n sdpcone
-    sdpcone[]
-end
-function CreateSDPCone(dsdp::DSDPT, arg2::Integer, arg3)
-    @dsdp_ccall DSDPCreateSDPCone (DSDPT, Cint, Ptr{SDPCone}) dsdp arg2 arg3
-end
-
-function SDPConeSetBlockSize(sdpcone::SDPCone, i::Integer, j::Integer)
-    @dsdp_ccall SDPConeSetBlockSize (SDPCone, Cint, Cint) sdpcone i j
-end
-
-function SDPConeGetBlockSize(arg1::SDPCone, arg2::Integer, arg3)
-    @dsdp_ccall SDPConeGetBlockSize (SDPCone, Cint, Ptr{Cint}) arg1 arg2 arg3
-end
-
-function SDPConeSetStorageFormat(arg1::SDPCone, arg2::Integer, arg3::UInt8)
-    @dsdp_ccall SDPConeSetStorageFormat (SDPCone, Cint, UInt8) arg1 arg2 arg3
-end
-
-function SDPConeGetStorageFormat(arg1::SDPCone, arg2::Integer, arg3)
-    @dsdp_ccall SDPConeGetStorageFormat (SDPCone, Cint, Cstring) arg1 arg2 arg3
-end
-
-function SDPConeCheckStorageFormat(arg1::SDPCone, arg2::Integer, arg3::UInt8)
-    @dsdp_ccall SDPConeCheckStorageFormat (SDPCone, Cint, UInt8) arg1 arg2 arg3
-end
-
-function SDPConeSetSparsity(arg1::SDPCone, arg2::Integer, arg3::Integer)
-    @dsdp_ccall SDPConeSetSparsity (SDPCone, Cint, Cint) arg1 arg2 arg3
-end
-
-function SDPConeView(arg1::SDPCone)
-    @dsdp_ccall SDPConeView (SDPCone,) arg1
-end
-
-function SDPConeView2(arg1::SDPCone)
-    @dsdp_ccall SDPConeView2 (SDPCone,) arg1
-end
-
-function SDPConeView3(arg1::SDPCone)
-    @dsdp_ccall SDPConeView3 (SDPCone,) arg1
-end
-
-function SDPConeSetASparseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
-    @dsdp_ccall SDPConeSetASparseVecMat (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
-end
-
-function SDPConeSetADenseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6, arg7::Integer)
-    @dsdp_ccall SDPConeSetADenseVecMat (SDPCone, Cint, Cint, Cint, Cdouble, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7
-end
-
-function SDPConeSetARankOneMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
-    @dsdp_ccall SDPConeSetARankOneMat (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
-end
-
-function SDPConeSetConstantMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
-    @dsdp_ccall SDPConeSetConstantMat (SDPCone, Cint, Cint, Cint, Cdouble) arg1 arg2 arg3 arg4 arg5
-end
-
-function SDPConeSetZeroMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer)
-    @dsdp_ccall SDPConeSetZeroMat (SDPCone, Cint, Cint, Cint) arg1 arg2 arg3 arg4
-end
-
-function SDPConeSetIdentity(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
-    @dsdp_ccall SDPConeSetIdentity (SDPCone, Cint, Cint, Cint, Cdouble) arg1 arg2 arg3 arg4 arg5
-end
-
-function SDPConeViewDataMatrix(arg1::SDPCone, arg2::Integer, arg3::Integer)
-    @dsdp_ccall SDPConeViewDataMatrix (SDPCone, Cint, Cint) arg1 arg2 arg3
-end
-
-function SDPConeMatrixView(arg1::SDPCone, arg2::Integer)
-    @dsdp_ccall SDPConeMatrixView (SDPCone, Cint) arg1 arg2
-end
-
-function SDPConeAddASparseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
-    @dsdp_ccall SDPConeAddASparseVecMat (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
-end
-
-function SDPConeAddADenseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6, arg7::Integer)
-    @dsdp_ccall SDPConeAddADenseVecMat (SDPCone, Cint, Cint, Cint, Cdouble, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7
-end
-
-function SDPConeAddConstantMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
-    @dsdp_ccall SDPConeAddConstantMat (SDPCone, Cint, Cint, Cint, Cdouble) arg1 arg2 arg3 arg4 arg5
-end
-
-function SDPConeAddIdentity(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
-    @dsdp_ccall SDPConeAddIdentity (SDPCone, Cint, Cint, Cint, Cdouble) arg1 arg2 arg3 arg4 arg5
-end
-
-function SDPConeAddARankOneMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
-    @dsdp_ccall SDPConeAddARankOneMat (SDPCone, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
-end
-
-function SDPConeAddSparseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Integer, arg6, arg7, arg8::Integer)
-    @dsdp_ccall SDPConeAddSparseVecMat (SDPCone, Cint, Cint, Cint, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8
-end
-
-function SDPConeAddDenseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5, arg6::Integer)
-    @dsdp_ccall SDPConeAddDenseVecMat (SDPCone, Cint, Cint, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6
-end
-
-function SDPConeSetSparseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Integer, arg6, arg7, arg8::Integer)
-    @dsdp_ccall SDPConeSetSparseVecMat (SDPCone, Cint, Cint, Cint, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8
-end
-
-function SDPConeSetDenseVecMat(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4::Integer, arg5, arg6::Integer)
-    @dsdp_ccall SDPConeSetDenseVecMat (SDPCone, Cint, Cint, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6
-end
-
-function SDPConeSetXMat(arg1::SDPCone, arg2::Integer, arg3::Integer)
-    @dsdp_ccall SDPConeSetXMat (SDPCone, Cint, Cint) arg1 arg2 arg3
-end
-
-function SDPConeSetXArray(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4, arg5::Integer)
-    @dsdp_ccall SDPConeSetXArray (SDPCone, Cint, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5
-end
-
-function SDPConeGetXArray(arg1::SDPCone, arg2::Integer, arg3, arg4)
-    @dsdp_ccall SDPConeGetXArray (SDPCone, Cint, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3 arg4
-end
-
-function SDPConeRestoreXArray(arg1::SDPCone, arg2::Integer, arg3, arg4)
-    @dsdp_ccall SDPConeRestoreXArray (SDPCone, Cint, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3 arg4
-end
-
-function SDPConeCheckData(arg1::SDPCone)
-    @dsdp_ccall SDPConeCheckData (SDPCone,) arg1
-end
-
-function SDPConeRemoveDataMatrix(arg1::SDPCone, arg2::Integer, arg3::Integer)
-    @dsdp_ccall SDPConeRemoveDataMatrix (SDPCone, Cint, Cint) arg1 arg2 arg3
-end
-
-function SDPConeGetNumberOfBlocks(arg1::SDPCone, arg2)
-    @dsdp_ccall SDPConeGetNumberOfBlocks (SDPCone, Ptr{Cint}) arg1 arg2
-end
-
-function SDPConeComputeS(arg1::SDPCone, arg2::Integer, arg3::Cdouble, arg4, arg5::Integer, arg6::Cdouble, arg7::Integer, arg8, arg9::Integer)
-    @dsdp_ccall SDPConeComputeS (SDPCone, Cint, Cdouble, Ptr{Cdouble}, Cint, Cdouble, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
-end
-
-function SDPConeComputeX(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4, arg5::Integer)
-    @dsdp_ccall SDPConeComputeX (SDPCone, Cint, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5
-end
-
-function SDPConeAddADotX(arg1::SDPCone, arg2::Integer, arg3::Cdouble, arg4, arg5::Integer, arg6, arg7::Integer)
-    @dsdp_ccall SDPConeAddADotX (SDPCone, Cint, Cdouble, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5 arg6 arg7
-end
-
-function SDPConeViewX(arg1::SDPCone, arg2::Integer, arg3::Integer, arg4, arg5::Integer)
-    @dsdp_ccall SDPConeViewX (SDPCone, Cint, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4 arg5
-end
-
-function SDPConeSetLanczosIterations(arg1::SDPCone, arg2::Integer)
-    @dsdp_ccall SDPConeSetLanczosIterations (SDPCone, Cint) arg1 arg2
-end
-
-function SDPConeScaleBarrier(arg1::SDPCone, arg2::Integer, arg3::Cdouble)
-    @dsdp_ccall SDPConeScaleBarrier (SDPCone, Cint, Cdouble) arg1 arg2 arg3
-end
-
-function SDPConeXVMultiply(sdpcone::SDPCone, arg2::Integer, arg3::Vector, arg4::Vector)
-    n = length(arg3)
-    @assert n == length(arg4)
-    @dsdp_ccall SDPConeXVMultiply (SDPCone, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint) sdpcone arg2 pointer(arg3) pointer(arg4) n
-end
-
-function SDPConeComputeXV(sdpcone::SDPCone, arg2::Integer)
-    derror = Ref{Cint}()
-    @dsdp_ccall SDPConeComputeXV (SDPCone, Cint, Ref{Cint}) sdpcone arg2 derror
-    derror[]
-end
-
-function SDPConeAddXVAV(arg1::SDPCone, arg2::Integer, arg3::Vector, arg5::Vector)
-    @dsdp_ccall SDPConeAddXVAV (SDPCone, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint) arg1 arg2 pointer(arg3) length(arg3) pointer(arg5) length(arg5)
-end
-
-function SDPConeUseLAPACKForDualMatrix(arg1::SDPCone, arg2::Integer)
-    @dsdp_ccall SDPConeUseLAPACKForDualMatrix (SDPCone, Cint) arg1 arg2
-end
-
 function SetDualObjective(dsdp::DSDPT, arg2::Integer, arg3::Cdouble)
     @dsdp_ccall DSDPSetDualObjective (DSDPT, Cint, Cdouble) dsdp arg2 arg3
 end
@@ -575,8 +292,8 @@ function ComputeMinimumXEigenvalue(dsdp::DSDPT, arg2)
     @dsdp_ccall DSDPComputeMinimumXEigenvalue (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
-function GetTraceX(dsdp::DSDPT, arg1)
-    @dsdp_ccall DSDPGetTraceX (DSDPT, Ptr{Cdouble}) dsdp arg1
+function GetTraceX(dsdp::DSDPT, sdpcone)
+    @dsdp_ccall DSDPGetTraceX (DSDPT, Ptr{Cdouble}) dsdp sdpcone
 end
 
 function SetZBar(dsdp::DSDPT, arg2::Cdouble)
@@ -595,12 +312,16 @@ function GetYMaxNorm(dsdp::DSDPT, arg2)
     @dsdp_ccall DSDPGetYMaxNorm (DSDPT, Ptr{Cdouble}) dsdp arg2
 end
 
-function SDPConeUseFullSymmetricFormat(arg1::SDPCone, arg2::Integer)
-    @dsdp_ccall SDPConeUseFullSymmetricFormat (SDPCone, Cint) arg1 arg2
+function BoundDualVariables(dsdp::DSDPT, arg2::Cdouble, arg3::Cdouble)
+    @dsdp_ccall DSDPBoundDualVariables (DSDPT, Cdouble, Cdouble) dsdp arg2 arg3
 end
 
-function SDPConeUsePackedFormat(arg1::SDPCone, arg2::Integer)
-    @dsdp_ccall SDPConeUsePackedFormat (SDPCone, Cint) arg1 arg2
+function SetYBounds(dsdp::DSDPT, arg2::Cdouble, arg3::Cdouble)
+    @dsdp_ccall DSDPSetYBounds (DSDPT, Cdouble, Cdouble) dsdp arg2 arg3
+end
+
+function GetYBounds(dsdp::DSDPT, arg2, arg3)
+    @dsdp_ccall DSDPGetYBounds (DSDPT, Ptr{Cdouble}, Ptr{Cdouble}) dsdp arg2 arg3
 end
 
 function SetFixedVariable(dsdp::DSDPT, arg2::Integer, arg3::Cdouble)
@@ -622,14 +343,6 @@ end
 function PrintOptions()
     ccall((:DSDPPrintOptions, libdsdp), Cint, ())
 end
-
-function PrintData(dsdp::DSDPT, arg2::SDPCone, arg3::LPCone)
-    @dsdp_ccall DSDPPrintData (DSDPT, SDPCone, LPCone) dsdp arg2 arg3
-end
-
-#function PrintSolution(arg1, arg2::DSDPT, arg3::SDPCone, arg4::LPCone)
-#    @dsdp_ccall DSDPPrintSolution (Ptr{FILE}, DSDP, SDPCone, LPCone) arg1 arg2 arg3 arg4
-#end
 
 function SetOptions(dsdp::DSDPT, arg2, arg3::Integer)
     @dsdp_ccall DSDPSetOptions (DSDPT, Ptr{Cstring}, Cint) dsdp arg2 arg3

--- a/src/lpcone.jl
+++ b/src/lpcone.jl
@@ -30,7 +30,7 @@ end
 
 # This function is not part of DSDP API
 function SetDataSparse(lpcone::LPConeT, n::Integer, nvars, lpdvars, lpdrows, lpcoefs)
-    SetData(lpcone, n, buildlp(nvar, lpdvars, lpdrows, lpcoefs)...)
+    SetData(lpcone, n, buildlp(nvars, lpdvars, lpdrows, lpcoefs)...)
 end
 
 function SetData(lpcone::LPConeT, n::Integer, nnzin::Vector{Cint}, row::Vector{Cint}, aval::Vector{Cdouble})
@@ -50,12 +50,18 @@ function ScaleBarrier(arg1::LPConeT, arg2::Cdouble)
     @dsdp_ccall LPConeScaleBarrier (LPConeT, Cdouble) arg1 arg2
 end
 
-function GetXArray(arg1::LPConeT, arg2, arg3)
-    @dsdp_ccall LPConeGetXArray (LPConeT, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3
+function GetXArray(lpcone::LPConeT)
+    xout = Ref{Ptr{Cdouble}}()
+    n = Ref{Cint}()
+    @dsdp_ccall LPConeGetXArray (LPConeT, Ptr{Ptr{Cdouble}}, Ptr{Cint}) lpcone xout n
+    unsafe_wrap(Array, xout[], n[])
 end
 
-function GetSArray(arg1::LPConeT, arg2, arg3)
-    @dsdp_ccall LPConeGetSArray (LPConeT, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3
+function GetSArray(lpcone::LPConeT)
+    sout = Ref{Ptr{Cdouble}}()
+    n = Ref{Cint}()
+    @dsdp_ccall LPConeGetSArray (LPConeT, Ref{Ptr{Cdouble}}, Ref{Cint}) lpcone sout n
+    unsafe_wrap(Array, sout[], n[])
 end
 
 function GetDimension(arg1::LPConeT, arg2)

--- a/src/lpcone.jl
+++ b/src/lpcone.jl
@@ -1,0 +1,77 @@
+export LPCone
+
+module LPCone
+
+import ..@dsdp_ccall
+const LPConeT = Ptr{Void}
+
+function buildlp(nvars, lpdvars, lpdrows, lpcoefs)
+    @assert length(lpdvars) == length(lpdrows) == length(lpcoefs)
+    nzin = zeros(Cint, nvars)
+    n = length(lpdvars)
+    for var in lpdvars
+        nzin[var] += 1
+    end
+    nnzin = [zero(Cint); cumsum(nzin)]
+    @assert nnzin[end] == n
+    idx = map(var -> Int[], 1:nvars)
+    for (i, var) in enumerate(lpdvars)
+        push!(idx[var], i)
+    end
+    row = Vector{Cint}(n)
+    aval = Vector{Cdouble}(n)
+    for var in 1:nvars
+        sort!(idx[var], by=i->lpdrows[i])
+        row[(nnzin[var]+1):(nnzin[var+1])] = lpdrows[idx[var]]
+        aval[(nnzin[var]+1):(nnzin[var+1])] = lpcoefs[idx[var]]
+    end
+    nnzin, row, aval
+end
+
+# This function is not part of DSDP API
+function SetDataSparse(lpcone::LPConeT, n::Integer, nvars, lpdvars, lpdrows, lpcoefs)
+    SetData(lpcone, n, buildlp(nvar, lpdvars, lpdrows, lpcoefs)...)
+end
+
+function SetData(lpcone::LPConeT, n::Integer, nnzin::Vector{Cint}, row::Vector{Cint}, aval::Vector{Cdouble})
+    @assert length(row) == length(aval)
+    @dsdp_ccall LPConeSetData (LPConeT, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}) lpcone n nnzin row aval
+end
+
+function SetData2(arg1::LPConeT, arg2::Integer, arg3, arg4, arg5)
+    @dsdp_ccall LPConeSetData2 (LPConeT, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}) arg1 arg2 arg3 arg4 arg5
+end
+
+function GetData(arg1::LPConeT, arg2::Integer, arg3, arg4::Integer)
+    @dsdp_ccall LPConeGetData (LPConeT, Cint, Ptr{Cdouble}, Cint) arg1 arg2 arg3 arg4
+end
+
+function ScaleBarrier(arg1::LPConeT, arg2::Cdouble)
+    @dsdp_ccall LPConeScaleBarrier (LPConeT, Cdouble) arg1 arg2
+end
+
+function GetXArray(arg1::LPConeT, arg2, arg3)
+    @dsdp_ccall LPConeGetXArray (LPConeT, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3
+end
+
+function GetSArray(arg1::LPConeT, arg2, arg3)
+    @dsdp_ccall LPConeGetSArray (LPConeT, Ptr{Ptr{Cdouble}}, Ptr{Cint}) arg1 arg2 arg3
+end
+
+function GetDimension(arg1::LPConeT, arg2)
+    @dsdp_ccall LPConeGetDimension (LPConeT, Ptr{Cint}) arg1 arg2
+end
+
+function View(lpcone::LPConeT)
+    @dsdp_ccall LPConeView (LPConeT,) lpcone
+end
+
+function View2(lpcone::LPConeT)
+    @dsdp_ccall LPConeView2 (LPConeT,) lpcone
+end
+
+function CopyS(arg1::LPConeT, arg2, arg3::Integer)
+    @dsdp_ccall LPConeCopyS (LPConeT, Ptr{Cdouble}, Cint) arg1 arg2 arg3
+end
+
+end

--- a/src/sdpcone.jl
+++ b/src/sdpcone.jl
@@ -1,0 +1,192 @@
+export SDPCone
+
+module SDPCone
+
+import ..@dsdp_ccall
+const SDPConeT = Ptr{Void}
+
+function SetBlockSize(sdpcone::SDPConeT, i::Integer, j::Integer)
+    @dsdp_ccall SDPConeSetBlockSize (SDPConeT, Cint, Cint) sdpcone i j
+end
+
+function GetBlockSize(sdpcone::SDPConeT, arg2::Integer, arg3)
+    @dsdp_ccall SDPConeGetBlockSize (SDPConeT, Cint, Ptr{Cint}) sdpcone arg2 arg3
+end
+
+function SetStorageFormat(sdpcone::SDPConeT, arg2::Integer, arg3::UInt8)
+    @dsdp_ccall SDPConeSetStorageFormat (SDPConeT, Cint, UInt8) sdpcone arg2 arg3
+end
+
+function GetStorageFormat(sdpcone::SDPConeT, arg2::Integer, arg3)
+    @dsdp_ccall SDPConeGetStorageFormat (SDPConeT, Cint, Cstring) sdpcone arg2 arg3
+end
+
+function CheckStorageFormat(sdpcone::SDPConeT, arg2::Integer, arg3::UInt8)
+    @dsdp_ccall SDPConeCheckStorageFormat (SDPConeT, Cint, UInt8) sdpcone arg2 arg3
+end
+
+function SetSparsity(sdpcone::SDPConeT, arg2::Integer, arg3::Integer)
+    @dsdp_ccall SDPConeSetSparsity (SDPConeT, Cint, Cint) sdpcone arg2 arg3
+end
+
+function View(sdpcone::SDPConeT)
+    @dsdp_ccall SDPConeView (SDPConeT,) sdpcone
+end
+
+function View2(sdpcone::SDPConeT)
+    @dsdp_ccall SDPConeView2 (SDPConeT,) sdpcone
+end
+
+function View3(sdpcone::SDPConeT)
+    @dsdp_ccall SDPConeView3 (SDPConeT,) sdpcone
+end
+
+function SetASparseVecMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
+    @dsdp_ccall SDPConeSetASparseVecMat (SDPConeT, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
+end
+
+function SetADenseVecMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6, arg7::Integer)
+    @dsdp_ccall SDPConeSetADenseVecMat (SDPConeT, Cint, Cint, Cint, Cdouble, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6 arg7
+end
+
+function SetARankOneMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
+    @dsdp_ccall SDPConeSetARankOneMat (SDPConeT, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
+end
+
+function SetConstantMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
+    @dsdp_ccall SDPConeSetConstantMat (SDPConeT, Cint, Cint, Cint, Cdouble) sdpcone arg2 arg3 arg4 arg5
+end
+
+function SetZeroMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer)
+    @dsdp_ccall SDPConeSetZeroMat (SDPConeT, Cint, Cint, Cint) sdpcone arg2 arg3 arg4
+end
+
+function SetIdentity(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
+    @dsdp_ccall SDPConeSetIdentity (SDPConeT, Cint, Cint, Cint, Cdouble) sdpcone arg2 arg3 arg4 arg5
+end
+
+function ViewDataMatrix(sdpcone::SDPConeT, arg2::Integer, arg3::Integer)
+    @dsdp_ccall SDPConeViewDataMatrix (SDPConeT, Cint, Cint) sdpcone arg2 arg3
+end
+
+function MatrixView(sdpcone::SDPConeT, arg2::Integer)
+    @dsdp_ccall SDPConeMatrixView (SDPConeT, Cint) sdpcone arg2
+end
+
+function AddASparseVecMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
+    @dsdp_ccall SDPConeAddASparseVecMat (SDPConeT, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
+end
+
+function AddADenseVecMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6, arg7::Integer)
+    @dsdp_ccall SDPConeAddADenseVecMat (SDPConeT, Cint, Cint, Cint, Cdouble, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6 arg7
+end
+
+function AddConstantMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
+    @dsdp_ccall SDPConeAddConstantMat (SDPConeT, Cint, Cint, Cint, Cdouble) sdpcone arg2 arg3 arg4 arg5
+end
+
+function AddIdentity(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble)
+    @dsdp_ccall SDPConeAddIdentity (SDPConeT, Cint, Cint, Cint, Cdouble) sdpcone arg2 arg3 arg4 arg5
+end
+
+function AddARankOneMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Cdouble, arg6::Integer, arg7, arg8, arg9::Integer)
+    @dsdp_ccall SDPConeAddARankOneMat (SDPConeT, Cint, Cint, Cint, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
+end
+
+function AddSparseVecMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Integer, arg6, arg7, arg8::Integer)
+    @dsdp_ccall SDPConeAddSparseVecMat (SDPConeT, Cint, Cint, Cint, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6 arg7 arg8
+end
+
+function AddDenseVecMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5, arg6::Integer)
+    @dsdp_ccall SDPConeAddDenseVecMat (SDPConeT, Cint, Cint, Cint, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6
+end
+
+function SetSparseVecMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5::Integer, arg6, arg7, arg8::Integer)
+    @dsdp_ccall SDPConeSetSparseVecMat (SDPConeT, Cint, Cint, Cint, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6 arg7 arg8
+end
+
+function SetDenseVecMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4::Integer, arg5, arg6::Integer)
+    @dsdp_ccall SDPConeSetDenseVecMat (SDPConeT, Cint, Cint, Cint, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6
+end
+
+function SetXMat(sdpcone::SDPConeT, arg2::Integer, arg3::Integer)
+    @dsdp_ccall SDPConeSetXMat (SDPConeT, Cint, Cint) sdpcone arg2 arg3
+end
+
+function SetXArray(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4, arg5::Integer)
+    @dsdp_ccall SDPConeSetXArray (SDPConeT, Cint, Cint, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5
+end
+
+function GetXArray(sdpcone::SDPConeT, arg2::Integer, arg3, arg4)
+    @dsdp_ccall SDPConeGetXArray (SDPConeT, Cint, Ptr{Ptr{Cdouble}}, Ptr{Cint}) sdpcone arg2 arg3 arg4
+end
+
+function RestoreXArray(sdpcone::SDPConeT, arg2::Integer, arg3, arg4)
+    @dsdp_ccall SDPConeRestoreXArray (SDPConeT, Cint, Ptr{Ptr{Cdouble}}, Ptr{Cint}) sdpcone arg2 arg3 arg4
+end
+
+function CheckData(sdpcone::SDPConeT)
+    @dsdp_ccall SDPConeCheckData (SDPConeT,) sdpcone
+end
+
+function RemoveDataMatrix(sdpcone::SDPConeT, arg2::Integer, arg3::Integer)
+    @dsdp_ccall SDPConeRemoveDataMatrix (SDPConeT, Cint, Cint) sdpcone arg2 arg3
+end
+
+function GetNumberOfBlocks(sdpcone::SDPConeT, arg2)
+    @dsdp_ccall SDPConeGetNumberOfBlocks (SDPConeT, Ptr{Cint}) sdpcone arg2
+end
+
+function ComputeS(sdpcone::SDPConeT, arg2::Integer, arg3::Cdouble, arg4, arg5::Integer, arg6::Cdouble, arg7::Integer, arg8, arg9::Integer)
+    @dsdp_ccall SDPConeComputeS (SDPConeT, Cint, Cdouble, Ptr{Cdouble}, Cint, Cdouble, Cint, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9
+end
+
+function ComputeX(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4, arg5::Integer)
+    @dsdp_ccall SDPConeComputeX (SDPConeT, Cint, Cint, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5
+end
+
+function AddADotX(sdpcone::SDPConeT, arg2::Integer, arg3::Cdouble, arg4, arg5::Integer, arg6, arg7::Integer)
+    @dsdp_ccall SDPConeAddADotX (SDPConeT, Cint, Cdouble, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5 arg6 arg7
+end
+
+function ViewX(sdpcone::SDPConeT, arg2::Integer, arg3::Integer, arg4, arg5::Integer)
+    @dsdp_ccall SDPConeViewX (SDPConeT, Cint, Cint, Ptr{Cdouble}, Cint) sdpcone arg2 arg3 arg4 arg5
+end
+
+function SetLanczosIterations(sdpcone::SDPConeT, arg2::Integer)
+    @dsdp_ccall SDPConeSetLanczosIterations (SDPConeT, Cint) sdpcone arg2
+end
+
+function ScaleBarrier(sdpcone::SDPConeT, arg2::Integer, arg3::Cdouble)
+    @dsdp_ccall SDPConeScaleBarrier (SDPConeT, Cint, Cdouble) sdpcone arg2 arg3
+end
+
+function XVMultiply(sdpcone::SDPConeT, arg2::Integer, arg3::Vector, arg4::Vector)
+    n = length(arg3)
+    @assert n == length(arg4)
+    @dsdp_ccall SDPConeXVMultiply (SDPConeT, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint) sdpcone arg2 pointer(arg3) pointer(arg4) n
+end
+
+function ComputeXV(sdpcone::SDPConeT, arg2::Integer)
+    derror = Ref{Cint}()
+    @dsdp_ccall SDPConeComputeXV (SDPConeT, Cint, Ref{Cint}) sdpcone arg2 derror
+    derror[]
+end
+
+function AddXVAV(sdpcone::SDPConeT, arg2::Integer, arg3::Vector, arg5::Vector)
+    @dsdp_ccall SDPConeAddXVAV (SDPConeT, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint) sdpcone arg2 pointer(arg3) length(arg3) pointer(arg5) length(arg5)
+end
+
+function UseLAPACKForDualMatrix(sdpcone::SDPConeT, arg2::Integer)
+    @dsdp_ccall SDPConeUseLAPACKForDualMatrix (SDPConeT, Cint) sdpcone arg2
+end
+
+function UseFullSymmetricFormat(sdpcone::SDPConeT, arg2::Integer)
+    @dsdp_ccall SDPConeUseFullSymmetricFormat (SDPConeT, Cint) sdpcone arg2
+end
+
+function UsePackedFormat(sdpcone::SDPConeT, arg2::Integer)
+    @dsdp_ccall SDPConeUsePackedFormat (SDPConeT, Cint) sdpcone arg2
+end
+
+end

--- a/test/build.jl
+++ b/test/build.jl
@@ -1,0 +1,12 @@
+@testset "LPConeSetData doc example" begin
+    lpdvars =    Cint[ 3, 3, 2, 2, 1, 3,  1,  1]
+    lpdrows =    Cint[ 2, 0, 1, 0, 0, 1,  1,  2]
+    lpcoefs = Cdouble[-1, 2, 3, 4, 6, 7, 10, 12]
+    nnzin, row, aval = LPCone.buildlp(3, lpdvars, lpdrows, lpcoefs)
+    @test nnzin isa Vector{Cint}
+    @test nnzin == [0, 3, 5, 8]
+    @test row isa Vector{Cint}
+    @test row == [0, 1, 2, 0, 1, 0, 1, 2]
+    @test aval isa Vector{Cdouble}
+    @test aval == [6, 10, 12, 4, 3, 2, 7, -1]
+end

--- a/test/maxcut.jl
+++ b/test/maxcut.jl
@@ -89,8 +89,7 @@ function maxcut(nnodes, edges)
 
     DSDP.Setup(dsdp)
 
-    info = DSDP.Solve(dsdp)
-    iszero(info) || error("Numerical error")
+    DSDP.Solve(dsdp)
     reason = DSDP.StopReason(dsdp)
 
     @test reason != DSDP.DSDP_INFEASIBLE_START

--- a/test/maxcut.jl
+++ b/test/maxcut.jl
@@ -1,7 +1,35 @@
-function di(i)
-    j = i - Cint(1)
-    div(j * i, Cint(2)) + j
+function di(u, v)
+    u, v = max(u, v), min(u, v)
+    div((u - Cint(1)) * u, Cint(2)) + (v - Cint(1))
 end
+di(u) = di(u, u)
+
+signz(t) = t < 0 ? -1 : 1
+
+# Apply the Goemens and Williamson randomized cut algorithm to the SDP relaxation of the max-cut problem
+function MaxCutRandomized(sdpcone::DSDP.SDPCone, nnodes::Integer)
+    ymin = Cdouble(0)
+
+    vv = Vector{Cdouble}(nnodes)
+    tt = Vector{Cdouble}(nnodes)
+    cc = Vector{Cdouble}(nnodes + 2)
+    DSDP.SDPConeComputeXV(sdpcone, 0)
+    for i in 1:nnodes
+        for j in eachindex(vv)
+            dd = rand() - .5
+            vv[j] = tan(π * dd)
+        end
+        DSDP.SDPConeXVMultiply(sdpcone, 0, vv, tt)
+        map!(signz, tt, tt)
+        map!(zero, cc, cc)
+        DSDP.SDPConeAddXVAV(sdpcone, 0, tt, cc)
+        if cc[1] < ymin
+            ymin = cc[1]
+        end
+    end
+    ymin
+end
+
 
 function maxcut(nnodes, edges)
     nedges = length(edges)
@@ -9,7 +37,6 @@ function maxcut(nnodes, edges)
     sdpcone = DSDP.CreateSDPCone(dsdp, 1)
 
     DSDP.SDPConeSetBlockSize(sdpcone, 0, nnodes)
-
 
     # Formulate the problem from the data
     # Diagonal elements equal 1.0
@@ -32,7 +59,7 @@ function maxcut(nnodes, edges)
     indd[nedges+(1:nnodes)] = iptr
     tval = 0.0
     for (i, (u, v, w)) in enumerate(edges)
-        indd[i] = (u-1) * u / 2 + v-1
+        indd[i] = di(u, v)
         tval += abs(w)
         val[i] = w / 4
         val[nedges+u]-= w/4
@@ -66,87 +93,28 @@ function maxcut(nnodes, edges)
     iszero(info) || error("Numerical error")
     reason = DSDP.StopReason(dsdp)
 
-    if reason != DSDP.DSDP_INFEASIBLE_START
-        # Randomized solution strategy
-#        info=MaxCutRandomized(sdpcone,nnodes)
-#        if false # Look at the solution
-#            int n; double *xx,*y=diag
-#            info = DSDPGetY(dsdp, y, nnodes)
-#            info = DSDPComputeX(dsdp)
-#            DSDPCHKERR(info)
-#            info = SDPConeGetXArray(sdpcone,0,&xx,&n)
-#        end
-    end
-    info = DSDP.Destroy(dsdp)
+    @test reason != DSDP.DSDP_INFEASIBLE_START
+    @test DSDP.GetDObjective(dsdp) ≈ -9.250079 rtol=1e-7
+    @test DSDP.GetDDObjective(dsdp) ≈ -9.250079 rtol=1e-7
+    @test DSDP.GetPObjective(dsdp) ≈ 1e10
+    @test DSDP.GetPPObjective(dsdp) ≈ -9.240522 rtol=1e-7
+    @test DSDP.GetDualityGap(dsdp) ≈ 0.009557113 rtol=1e-7
+
+    # Randomized solution strategy
+    @test MaxCutRandomized(sdpcone, nnodes) ≈ -9.25
+
+    DSDP.Destroy(dsdp)
 end
 
-maxcut(1, [(1, 1, 1)])
-
-
-#    # Initial Point
-#    info = DSDPSetR0(dsdp,0.0)
-#    info = DSDPSetZBar(dsdp,10*tval+1.0)
-#    for i in 1:nnodes
-#        info = DSDPSetY0(dsdp, i+1, 10*yy[i])
-#    end
-#    iszero(info) || return info
-#
-#    # Get read to go
-#    info = DSDPSetGapTolerance(dsdp, 0.001)
-#    info = DSDPSetPotentialParameter(dsdp, 5)
-#    info = DSDPReuseMatrix(dsdp, 0)
-#    info = DSDPSetPNormTolerance(dsdp, 1.0)
-#    #info = TCheckArgs(dsdp,argc,argv)
-#
-#    iszero(info) || error("Out of memory")
-#    info = DSDPSetStandardMonitor(dsdp,1)
-#
-#    info = DSDPSetup(dsdp)
-#    iszero(info) || error("Out of memory")
-#
-#    info = DSDPSolve(dsdp)
-#    iszero(info) || error("Numerical error")
-#    info = DSDPStopReason(dsdp, &reason)
-#
-#    if reason != DSDP_INFEASIBLE_START
-#        # Randomized solution strategy
-#        info=MaxCutRandomized(sdpcone,nnodes)
-#        if false # Look at the solution
-#            int n; double *xx,*y=diag
-#            info = DSDPGetY(dsdp, y, nnodes)
-#            info = DSDPComputeX(dsdp)
-#            DSDPCHKERR(info)
-#            info = SDPConeGetXArray(sdpcone,0,&xx,&n)
-#        end
-#    end
-#    info = DSDPDestroy(dsdp)
-#end
-#
-#signz(t) = t < 0 ? -1 : 1
-#
-## maxcutrandomized(sdpcone::SDPCone, nnodes::Int)
-## Apply the Goemens and Williamson randomized cut algorithm to the SDP relaxation of the max-cut problem
-## sdpcone the SDP cone
-## nnodes number of nodes in the graph
-#function maxcutrandomized(sdpcone::SDPCone, nnodes::Int)
-#    ymin = 0
-#
-#    vv = Vector{Cdouble}(nnodes)
-#    tt = Vector{Cdouble}(nnodes)
-#    cc = Vector{Cdouble}(nnodes+2)
-#    info = SDPConeComputeXV(sdpcone, 0, &derror)
-#    for i in 1:nnodes
-#        for j in 1:nnodes
-#            dd = rand() - .5
-#            vv[j] = tan(pi*dd)
-#        end
-#        info = SDPConeXVMultiply(sdpcone, 0, vv, tt, nnodes)
-#        map!(signz, tt)
-#        map!(zero, cc)
-#        info = SDPConeAddXVAV(sdpcone, 0, tt, nnodes, cc, nnodes+2)
-#        if cc[1] < ymin
-#            ymin = cc[1]
-#        end
-#    end
-#    printf("Best integer solution: %4.2f\n",ymin);
-#end
+@testset "DSDP MaxCut example" begin
+    const nnodes = 6
+    const edges = [(1, 2,   .3)
+                   (1, 4,  2.7)
+                   (1, 6,  1.5)
+                   (2, 3, -1.0)
+                   (2, 5,  1.45)
+                   (3, 4, -0.2)
+                   (4, 5,  1.2)
+                   (5, 6,  2.1)]
+    maxcut(nnodes, edges)
+end

--- a/test/maxcut.jl
+++ b/test/maxcut.jl
@@ -7,22 +7,22 @@ di(u) = di(u, u)
 signz(t) = t < 0 ? -1 : 1
 
 # Apply the Goemens and Williamson randomized cut algorithm to the SDP relaxation of the max-cut problem
-function MaxCutRandomized(sdpcone::DSDP.SDPCone, nnodes::Integer)
+function MaxCutRandomized(sdpcone::SDPCone.SDPConeT, nnodes::Integer)
     ymin = Cdouble(0)
 
     vv = Vector{Cdouble}(nnodes)
     tt = Vector{Cdouble}(nnodes)
     cc = Vector{Cdouble}(nnodes + 2)
-    DSDP.SDPConeComputeXV(sdpcone, 0)
+    SDPCone.ComputeXV(sdpcone, 0)
     for i in 1:nnodes
         for j in eachindex(vv)
             dd = rand() - .5
             vv[j] = tan(π * dd)
         end
-        DSDP.SDPConeXVMultiply(sdpcone, 0, vv, tt)
+        SDPCone.XVMultiply(sdpcone, 0, vv, tt)
         map!(signz, tt, tt)
         map!(zero, cc, cc)
-        DSDP.SDPConeAddXVAV(sdpcone, 0, tt, cc)
+        SDPCone.AddXVAV(sdpcone, 0, tt, cc)
         if cc[1] < ymin
             ymin = cc[1]
         end
@@ -36,7 +36,7 @@ function maxcut(nnodes, edges)
     dsdp = DSDP.Create(nnodes)
     sdpcone = DSDP.CreateSDPCone(dsdp, 1)
 
-    DSDP.SDPConeSetBlockSize(sdpcone, 0, nnodes)
+    SDPCone.SetBlockSize(sdpcone, 0, nnodes)
 
     # Formulate the problem from the data
     # Diagonal elements equal 1.0
@@ -48,7 +48,7 @@ function maxcut(nnodes, edges)
 
     for i in 1:nnodes
         DSDP.SetDualObjective(dsdp, i, 1.0)
-        DSDP.SDPConeSetASparseVecMat(sdpcone, 0, i, nnodes, 1.0, 0, pointer(iptr, i), pointer(diag, i), 1)
+        SDPCone.SetASparseVecMat(sdpcone, 0, i, nnodes, 1.0, 0, pointer(iptr, i), pointer(diag, i), 1)
     end
 
     # C matrix is the Laplacian of the adjacency matrix
@@ -68,8 +68,8 @@ function maxcut(nnodes, edges)
         yy[v] -= abs(w/2)
     end
 
-    DSDP.SDPConeSetASparseVecMat(sdpcone,0,0,nnodes,1.0,0,pointer(indd),pointer(val),nedges)
-    DSDP.SDPConeAddASparseVecMat(sdpcone,0,0,nnodes,1.0,0,pointer(indd,nedges+1),pointer(val,nedges+1),nnodes)
+    SDPCone.SetASparseVecMat(sdpcone,0,0,nnodes,1.0,0,pointer(indd),pointer(val),nedges)
+    SDPCone.AddASparseVecMat(sdpcone,0,0,nnodes,1.0,0,pointer(indd,nedges+1),pointer(val,nedges+1),nnodes)
 
     # Initial Point
     DSDP.SetR0(dsdp,0.0)

--- a/test/moi.jl
+++ b/test/moi.jl
@@ -1,0 +1,16 @@
+@testset "Linear tests" begin
+    include(joinpath(Pkg.dir("MathOptInterface"), "test", "contlinear.jl"))
+    linear2test(DSDP.DSDPSolver(), atol=1e-7, rtol=1e-7)
+    linear3test(DSDP.DSDPSolver(), atol=1e-7, rtol=1e-7)
+    linear4test(DSDP.DSDPSolver(), atol=1e-7, rtol=1e-7)
+    linear5test(DSDP.DSDPSolver(), atol=1e-7, rtol=1e-7)
+    linear6test(DSDP.DSDPSolver(), atol=1e-6, rtol=1e-6)
+    linear7test(DSDP.DSDPSolver(), atol=1e-6, rtol=1e-6)
+    linear8test(DSDP.DSDPSolver(), atol=1e-7, rtol=1e-7)
+    linear9test(DSDP.DSDPSolver(), atol=1e-7, rtol=1e-7)
+    linear10test(DSDP.DSDPSolver(), atol=1e-7, rtol=1e-7)
+end
+#@testset "Conic tests" begin
+#    include(joinpath(Pkg.dir("MathOptInterface"), "test", "contconic.jl"))
+#    contconictest(CSDP.CSDPSolver(printlevel=0), atol=1e-7, rtol=1e-7)
+#end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using Base.Test
 
 include("maxcut.jl")
 include("build.jl")
+include("moi.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,3 +2,4 @@ using DSDP
 using Base.Test
 
 include("maxcut.jl")
+include("build.jl")


### PR DESCRIPTION
This PR
* finishes the MaxCut test
* creates a submodule for each cone to mimic the terminology of DSDP (e.g. SDPConeblah is now SDPCone.blah).
* creates a utility `SetDataSparse` to make it easier to implement an MOI wrapper
* Implements the MOI wrapper for LP, it passes linear2test -> linear10test